### PR TITLE
Fixes some of the larp gun stuff I missed or that we found

### DIFF
--- a/modular_np_lethal/deepmaint_stuff/code/resupply_doohickey.dm
+++ b/modular_np_lethal/deepmaint_stuff/code/resupply_doohickey.dm
@@ -30,6 +30,9 @@
 				/obj/item/ammo_box/magazine/ammo_stack/c40_sol/prefilled = INFINITY,
 				/obj/item/ammo_box/magazine/ammo_stack/c310_strilka/prefilled = INFINITY,
 				/obj/item/ammo_box/magazine/ammo_stack/c60_strela/prefilled = INFINITY,
+				/obj/item/ammo_box/magazine/ammo_stack/c12chinmoku/prefilled = INFINITY,
+				/obj/item/ammo_box/magazine/ammo_stack/c8marsian/prefilled = INFINITY,
+				/obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled = INFINITY,
 			),
 		),
 	)

--- a/modular_np_lethal/epic_loot/code/random_spawners.dm
+++ b/modular_np_lethal/epic_loot/code/random_spawners.dm
@@ -485,6 +485,18 @@
 		/obj/item/ammo_box/c27_54cesarzowa = 2,
 		/obj/item/ammo_box/magazine/ammo_stack/c27_54cesarzowa/prefilled/incapacitator = 2,
 		/obj/item/ammo_box/c27_54cesarzowa/rubber = 2,
+		// 12mm silenced
+		/obj/item/ammo_box/magazine/ammo_stack/c12chinmoku/prefilled = 2,
+		/obj/item/ammo_box/magazine/ammo_stack/c12chinmoku/prefilled/special = 1,
+		/obj/item/ammo_box/magazine/ammo_stack/c12chinmoku/prefilled/tracer = 2,
+		// 8mm mars
+		/obj/item/ammo_box/magazine/ammo_stack/c8marsian/prefilled = 2,
+		/obj/item/ammo_box/magazine/ammo_stack/c8marsian/prefilled/shockwave = 1,
+		/obj/item/ammo_box/magazine/ammo_stack/c8marsian/prefilled/piercing = 1,
+		// 6 gauge
+		/obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled = 2,
+		/obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled/longshot = 1,
+		/obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled/slug = 2,
 		// .60
 		/obj/item/ammo_box/magazine/ammo_stack/c60_strela/prefilled = 2,
 		/obj/item/ammo_casing/p60strela = 2,
@@ -500,6 +512,10 @@
 		/obj/item/ammo_box/magazine/miecz = 2,
 		/obj/item/ammo_box/magazine/recharge/plasma_battery = 2,
 		/obj/item/ammo_box/magazine/wylom = 1,
+		/obj/item/ammo_box/magazine/c12chinmoku = 2,
+		/obj/item/ammo_box/magazine/c12chinmoku/standard = 1,
+		/obj/item/ammo_box/magazine/c12nomi = 2,
+		/obj/item/ammo_box/magazine/c8marsian = 2,
 		// Shotgun shells
 		/obj/item/ammo_box/magazine/ammo_stack/s12gauge/prefilled = 1,
 		/obj/item/ammo_box/magazine/ammo_stack/s12gauge/prefilled/antitide = 1,
@@ -549,6 +565,8 @@
 		/obj/item/gun/ballistic/automatic/pistol/plasma_marksman = 2,
 		/obj/item/gun/ballistic/revolver/shotgun_revolver = 2,
 		/obj/item/gun/ballistic/automatic/miecz = 1,
+		/obj/item/gun/ballistic/automatic/seiba_smg = 1,
+		/obj/item/gun/ballistic/automatic/pistol/weevil = 2,
 		/obj/item/storage/toolbox/ammobox/epic_loot = 1,
 		/obj/item/storage/toolbox/ammobox/epic_loot/magazine_box = 1,
 	)
@@ -578,6 +596,13 @@
 		/obj/item/gun/ballistic/automatic/wylom = 1,
 		/obj/item/storage/toolbox/ammobox/epic_loot = 1,
 		/obj/item/storage/toolbox/ammobox/epic_loot/magazine_box = 1,
+		/obj/item/gun/ballistic/automatic/suppressed_rifle = 2,
+		/obj/item/gun/ballistic/automatic/suppressed_rifle/grenade_launcher = 1,
+		/obj/item/gun/ballistic/automatic/suppressed_rifle/marksman = 2,
+		/obj/item/gun/ballistic/marsian_super_rifle = 2,
+		/obj/item/gun/ballistic/rifle/chokyu = 1,
+		/obj/item/gun/ballistic/shotgun/ramu = 1,
+		/obj/item/gun/ballistic/automatic/nomi_shotgun = 1,
 	)
 
 /obj/effect/spawner/random/epic_loot/random_other_military_loot

--- a/modular_np_lethal/lethalguns/code/bullets.dm
+++ b/modular_np_lethal/lethalguns/code/bullets.dm
@@ -11,6 +11,8 @@
 	caliber = CALIBER_12MMCHINMOKU
 	projectile_type = /obj/projectile/bullet/c12chinmoku
 
+	ammo_stack_type = /obj/item/ammo_box/magazine/ammo_stack/c12chinmoku
+
 /obj/projectile/bullet/c12chinmoku
 	name = "12mm Chinmoku bullet"
 	damage = 40
@@ -111,6 +113,8 @@
 	caliber = CALIBER_8MMMARSIAN
 	projectile_type = /obj/projectile/bullet/c8marsian
 
+	ammo_stack_type = /obj/item/ammo_box/magazine/ammo_stack/c8marsian
+
 /obj/projectile/bullet/c8marsian
 	name = "8mm Marsian bullet"
 	icon_state = "gauss"
@@ -205,6 +209,8 @@
 	pellets = 8
 	variance = 35
 
+	ammo_stack_type = /obj/item/ammo_box/magazine/ammo_stack/s6gauge
+
 /obj/projectile/bullet/s6gauge
 	name = "6 gauge buckshot pellet"
 	damage = 7.5
@@ -219,7 +225,7 @@
 	desc = "A stack of 6 gauge shells."
 	caliber = CALIBER_6GAUGE
 	ammo_type = /obj/item/ammo_casing/s6gauge
-	max_ammo = 6
+	max_ammo = 4
 	casing_x_positions = list(
 		-8,
 		-4,

--- a/modular_np_lethal/lethalguns/code/bullets.dm
+++ b/modular_np_lethal/lethalguns/code/bullets.dm
@@ -13,15 +13,15 @@
 
 /obj/projectile/bullet/c12chinmoku
 	name = "12mm Chinmoku bullet"
-	damage = 50
+	damage = 40
 	spread = 2
 
 	wound_bonus = 10
 	bare_wound_bonus = 20
 
-	wound_falloff_tile = 1
+	wound_falloff_tile = 2
 	damage_falloff_tile = 3
-	speed = 1.5
+	speed = 1.2
 
 /obj/item/ammo_box/magazine/ammo_stack/c12chinmoku
 	name = "12mm Chinmoku casings"
@@ -63,12 +63,12 @@
 
 /obj/projectile/bullet/c12chinmoku/special
 	name = "12mm Chinmoku 'special' bullet"
-	damage = 50
+	damage = 40
 	armour_penetration = 30
 	spread = 4
 
 	wound_falloff_tile = 1.5
-	damage_falloff_tile = 4
+	damage_falloff_tile = 5
 
 // Chinmoku tracer, the same as regular chinmoku but it looks cool as fuck in the dark
 

--- a/modular_np_lethal/lethalguns/code/bullets.dm
+++ b/modular_np_lethal/lethalguns/code/bullets.dm
@@ -238,10 +238,10 @@
 /obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled
 	start_empty = FALSE
 
-/obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled/special
+/obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled/longshot
 	ammo_type = /obj/item/ammo_casing/s6gauge/longshot
 
-/obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled/tracer
+/obj/item/ammo_box/magazine/ammo_stack/s6gauge/prefilled/slug
 	ammo_type = /obj/item/ammo_casing/s6gauge/slug
 
 // 6 gauge buckshot but with a spread better made for longer range fighting

--- a/modular_np_lethal/lethalguns/code/shotgun.dm
+++ b/modular_np_lethal/lethalguns/code/shotgun.dm
@@ -36,6 +36,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 
+	recoil = 2
+
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/s6gauge
 
 /obj/item/gun/ballistic/shotgun/ramu/give_manufacturer_examine()
@@ -97,6 +99,7 @@
 	fire_delay = 0.5 SECONDS
 
 	projectile_wound_bonus = -10
+	recoil = 0.5
 
 /obj/item/gun/ballistic/automatic/nomi_shotgun/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_XHIHAO)

--- a/modular_np_lethal/lethalguns/code/suppressed.dm
+++ b/modular_np_lethal/lethalguns/code/suppressed.dm
@@ -103,9 +103,17 @@
 
 /obj/item/gun/ballistic/automatic/suppressed_rifle/grenade_launcher/attackby(obj/item/attacking, mob/user, params)
 	if(isammocasing(attacking))
-		if(istype(attacking, underbarrel.magazine.ammo_type))
+		var/obj/item/ammo_casing/attacking_casing = attacking
+		if(attacking_casing.caliber == underbarrel.magazine.caliber)
 			underbarrel.attack_self(user)
 			underbarrel.attackby(attacking, user, params)
+	else if(isammobox(attacking))
+		var/obj/item/ammo_box/attacking_box = attacking
+		if(attacking_box.caliber == underbarrel.magazine.caliber)
+			underbarrel.attack_self(user)
+			underbarrel.attackby(attacking, user, params)
+		else
+			..()
 	else
 		..()
 
@@ -148,7 +156,7 @@
 	fire_delay = 0.5 SECONDS
 	spread = 0
 
-	projectile_damage_multiplier = 1.2
+	projectile_damage_multiplier = 1.5
 
 /obj/item/gun/ballistic/automatic/suppressed_rifle/marksman/Initialize(mapload)
 	. = ..()

--- a/modular_np_lethal/lethalguns/code/suppressed.dm
+++ b/modular_np_lethal/lethalguns/code/suppressed.dm
@@ -157,6 +157,7 @@
 	spread = 0
 
 	projectile_damage_multiplier = 1.5
+	recoil = 0.5
 
 /obj/item/gun/ballistic/automatic/suppressed_rifle/marksman/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

See title

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

see title?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: the .980 UBGL can be loaded with both individual grenades or an ammo box with grenades
qol: 6 gauge shells come in stacks of 4 instead of six, since the gun only holds four shells
balance: 12mm chinmoku does less damage and falls off harder, but is fired faster than before
balance: some guns lacking recoil, like the ramu, now have it
fix: 6 gauge, 12mm, and 8mm can now be made into ammo stacks like they should have been able to do
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
