### PR TITLE
Actually for real this time fixes armor

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -166,7 +166,7 @@
  * * damage_type: BRUTE or BURN
  * * armour_penetration: If the attack had armour_penetration
  */
-/obj/item/clothing/proc/take_damage_zone(def_zone, damage_amount, damage_type, armour_penetration)
+/* /obj/item/clothing/proc/take_damage_zone(def_zone, damage_amount, damage_type, armour_penetration) // LETHALSTATION OVERRIDE - modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
 	if(!def_zone || !limb_integrity || (initial(body_parts_covered) in GLOB.bitflags)) // the second check sees if we only cover one bodypart anyway and don't need to bother with this
 		return
 	var/list/covered_limbs = cover_flags2body_zones(body_parts_covered) // what do we actually cover?
@@ -177,7 +177,7 @@
 	LAZYINITLIST(damage_by_parts)
 	damage_by_parts[def_zone] += damage_dealt
 	if(damage_by_parts[def_zone] > limb_integrity)
-		disable_zone(def_zone, damage_type)
+		disable_zone(def_zone, damage_type) */ // LETHALSTATION OVERRIDE - modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
 
 /**
  * disable_zone() is used to disable a given bodypart's protection on our clothing item, mainly from [/obj/item/clothing/proc/take_damage_zone]

--- a/modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
+++ b/modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
@@ -33,7 +33,7 @@
 	// on [/atom/proc/bullet_act] where it's just to pass it to the projectile's on_hit().
 	var/armor_check = check_projectile_armor(def_zone, hitting_projectile, is_silent = TRUE)
 
-	var/flat_reduction = getarmor(def_zone, BULLET) / 4
+	var/flat_reduction = getarmor(def_zone, hitting_projectile.armor_flag) / 4
 	var/armor_damage = ((hitting_projectile.armour_penetration + 100) / 100) * (hitting_projectile.damage - (hitting_projectile.damage - flat_reduction))
 
 	apply_damage(
@@ -62,10 +62,10 @@
 	)
 
 	// If the damage type isn't one of the types that already does clothing damage, then we damage armor
-	if((hitting_projectile.damage_type == BRUTE) && !(hitting_projectile.sharpness & SHARP_EDGED))
+	if((hitting_projectile.armor_flag == BULLET) && !(hitting_projectile.sharpness & SHARP_EDGED))
 		damage_armor(
 			armor_damage,
-			hitting_projectile.damage_type,
+			hitting_projectile.armor_flag,
 			def_zone,
 		)
 

--- a/modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
+++ b/modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
@@ -62,7 +62,7 @@
 	)
 
 	// If the damage type isn't one of the types that already does clothing damage, then we damage armor
-	if((hitting_projectile.armor_flag == BULLET) && !(hitting_projectile.sharpness & SHARP_EDGED))
+	if(hitting_projectile.damage_type != BURN)
 		damage_armor(
 			armor_damage,
 			hitting_projectile.armor_flag,

--- a/modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
+++ b/modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
@@ -65,10 +65,24 @@
 	if(hitting_projectile.damage_type != BURN)
 		damage_armor(
 			armor_damage,
-			hitting_projectile.armor_flag,
+			hitting_projectile.damage_type,
 			def_zone,
 		)
 
 	if(hitting_projectile.dismemberment)
 		check_projectile_dismemberment(hitting_projectile, def_zone)
 	return BULLET_ACT_HIT
+
+// Override take_damage_zone to allow stuff with only one covered zone to take damage
+/obj/item/clothing/proc/take_damage_zone(def_zone, damage_amount, damage_type, armour_penetration)
+	if(!def_zone || !limb_integrity) // the second check sees if we only cover one bodypart anyway and don't need to bother with this
+		return
+	var/list/covered_limbs = cover_flags2body_zones(body_parts_covered) // what do we actually cover?
+	if(!(def_zone in covered_limbs))
+		return
+
+	var/damage_dealt = take_damage(damage_amount * 0.1, damage_type, "", FALSE, 1, 100) * 10 // only deal 10% of the damage to the general integrity damage, then multiply it by 10 so we know how much to deal to limb
+	LAZYINITLIST(damage_by_parts)
+	damage_by_parts[def_zone] += damage_dealt
+	if(damage_by_parts[def_zone] > limb_integrity)
+		disable_zone(def_zone, damage_type)

--- a/modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
+++ b/modular_np_lethal/armor_but_cool/code/armor_damage_by_bullets.dm
@@ -1,5 +1,5 @@
 /// Checks the armor that the person is wearing when they are attacked and damages it under the correct conditions
-/mob/living/proc/damage_armor(damage = 0, damage_flag = MELEE, damage_type = BRUTE, sharpness = NONE, def_zone = BODY_ZONE_CHEST)
+/mob/living/proc/damage_armor(damage = 0, damage_type = BRUTE, def_zone = BODY_ZONE_CHEST)
 	return FALSE
 
 /mob/living/carbon/human/damage_armor(damage = 0, damage_type = BRUTE, def_zone = BODY_ZONE_CHEST)
@@ -33,7 +33,7 @@
 	// on [/atom/proc/bullet_act] where it's just to pass it to the projectile's on_hit().
 	var/armor_check = check_projectile_armor(def_zone, hitting_projectile, is_silent = TRUE)
 
-	var/flat_reduction = getarmor(def_zone, hitting_projectile.armor_flag) / 4
+	var/flat_reduction = getarmor(def_zone, BULLET) / 4
 	var/armor_damage = ((hitting_projectile.armour_penetration + 100) / 100) * (hitting_projectile.damage - (hitting_projectile.damage - flat_reduction))
 
 	apply_damage(
@@ -62,7 +62,7 @@
 	)
 
 	// If the damage type isn't one of the types that already does clothing damage, then we damage armor
-	if((hitting_projectile.damage_type == BRUTE) && !(hitting_projectile.sharpness = SHARP_EDGED))
+	if((hitting_projectile.damage_type == BRUTE) && !(hitting_projectile.sharpness & SHARP_EDGED))
 		damage_armor(
 			armor_damage,
 			hitting_projectile.damage_type,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Eternal damnation

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

Armor breaks correctly now

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

I did

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Armor now correctly breaks when shot at enough
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
