### PR TITLE
adds a minimum fuze to impact grenades

### DIFF
--- a/modular_np_lethal/lethalguns/code/grenades.dm
+++ b/modular_np_lethal/lethalguns/code/grenades.dm
@@ -1,22 +1,40 @@
+// Impact grenades for offense, has no shrapnel and a pretty small kaboom
+
 /obj/item/grenade/syndieminibomb/concussion/impact
 	name = "Offensive Impact Grenade"
-	desc = "An impact-fuzed grenade with no shrapnel and a relatively small explosive mass for offensive action."
+	desc = "An impact-fuzed grenade with no shrapnel and a relatively small explosive mass for offensive action. \
+		The impact explosive will not be ready until <b>1/3 of the 5 second arming time has passed</b> and it will \
+		behave like a <b>regular grenade</b> if thrown <b>before that time</b>."
 	icon = 'modular_np_lethal/lethalguns/icons/grenades.dmi'
 	icon_state = "impact_offense"
 	ex_dev = 0
 	ex_heavy = 0
 	ex_light = 2
 	ex_flame = 2
+	/// Can this grenade explode on impact yet?
+	var/impact_explosion_ready = FALSE
 
 /obj/item/grenade/syndieminibomb/concussion/impact/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
-	if(!active)
+	if(!impact_explosion_ready)
 		return
 	detonate()
 
+/obj/item/grenade/syndieminibomb/concussion/impact/arm_grenade(mob/user, delayoverride, msg = TRUE, volume = 60)
+	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(ready_impact)), det_time / 3)
+
+/// Allows the grenade to explode on throw impact
+/obj/item/grenade/syndieminibomb/concussion/impact/proc/ready_impact()
+	impact_explosion_ready = TRUE
+
+// Impact grenades for defense, has shrapnel and a bigger boom
+
 /obj/item/grenade/frag/impact
 	name = "Defensive Impact Grenade"
-	desc = "An impact-fuzed grenade with large amounts of shrapnel and high explosive mass for defensive action."
+	desc = "An impact-fuzed grenade with large amounts of shrapnel and high explosive mass for defensive action. \
+		The impact explosive will not be ready until <b>1/2 of the 5 second arming time has passed</b> and it will \
+		behave like a <b>regular grenade</b> if thrown <b>before that time</b>."
 	icon = 'modular_np_lethal/lethalguns/icons/grenades.dmi'
 	icon_state = "impact_defense"
 	shrapnel_type = /obj/projectile/bullet/shrapnel
@@ -25,9 +43,19 @@
 	ex_heavy = 0
 	ex_light = 3
 	ex_flame = 4
+	/// Can this grenade explode on impact yet?
+	var/impact_explosion_ready = FALSE
 
 /obj/item/grenade/frag/impact/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
-	if(!active)
+	if(!impact_explosion_ready)
 		return
 	detonate()
+
+/obj/item/grenade/frag/impact/arm_grenade(mob/user, delayoverride, msg = TRUE, volume = 60)
+	. = ..()
+	addtimer(CALLBACK(src, PROC_REF(ready_impact)), det_time / 2)
+
+/// Allows the grenade to explode on throw impact
+/obj/item/grenade/frag/impact/proc/ready_impact()
+	impact_explosion_ready = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

both types of impact grenades now have a minimum timer that must pass before they explode instantly on impact

defensive is 1/2 of the fuze time, offensive is 1/3 of the fuze time

if thrown before this time has passed, they will instead behave like a regular grenade

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Nova Sector Roleplay Experience

aditi sharma impact grenade grenadier belt incident

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

nah id win

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Impact grenades, both offensive and defensive, require 1/3 or 1/2 of their regular fuze timer respectively to pass before the impact action actually works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
