### PR TITLE
Mechbuffs (this time for sure.)

### DIFF
--- a/code/modules/vehicles/mecha/mech_melee_attack.dm
+++ b/code/modules/vehicles/mecha/mech_melee_attack.dm
@@ -70,9 +70,9 @@
 		switch(mecha_attacker.damtype)
 			if(BRUTE)
 				if(mecha_attacker.force > 35) // durand and other heavy mechas
-					Unconscious(20)
+					Unconscious(0) // LETHAL EDIT Unconscious(20)
 				else if(mecha_attacker.force > 20 && !IsKnockdown()) // lightweight mechas like gygax
-					Knockdown(40)
+					Knockdown(0) // LETHAL EDIT Knockdown(40)
 				selected_zone.receive_damage(dmg, 0, updating_health = TRUE)
 				playsound(src, 'sound/weapons/punch4.ogg', 50, TRUE)
 			if(FIRE)

--- a/modular_np_lethal/loadout_items/mech_beacon.dm
+++ b/modular_np_lethal/loadout_items/mech_beacon.dm
@@ -16,7 +16,9 @@
 		exosuit_packs = list()
 		var/list/possible_exosuit_packs = list(
 			/obj/vehicle/sealed/mecha/gygax/streetsweeper,
-			/obj/vehicle/sealed/mecha/savannah_ivanov/exstasi
+			/obj/vehicle/sealed/mecha/savannah_ivanov/exstasi,
+			/obj/vehicle/sealed/mecha/durand/tortuga,
+			/obj/vehicle/sealed/mecha/marauder/horizon
 		)
 		for(var/obj/vehicle/sealed/mecha/exosuit_pack as anything in possible_exosuit_packs)
 			exosuit_packs[initial(exosuit_pack.name)] = exosuit_pack
@@ -25,10 +27,10 @@
 //special pre equipped exosuits for it to deploy. they get max ammo and better parts.
 /obj/vehicle/sealed/mecha/gygax/streetsweeper
 	name = "\improper Gygax 'Streetsweeper'"
-	desc = "A medium, high mobility exosuit equipped with an LBX-10 Autocannon and PEP-6 anti-structural missiles, intended for breachwork and urban crowd control."
+	desc = "A light weight, high mobility exosuit equipped with an LBX-10 Autocannon and heavy laser, intended for breachwork and urban crowd control."
 	equip_by_category = list(
 		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot,
-		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching,
+		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy,
 		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full),
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(),)
@@ -48,8 +50,8 @@
 	name = "\improper Savannah Ivanov 'Ecstasy of Saint Teresa'"
 	desc = "A high mobility fire support mech with a lightweight, long range loadout, named for Bernini's masterpiece sculpture of Teresa of Avila."
 	equip_by_category = list(
-		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
-		MECHA_R_ARM = null,
+		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser,
+		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/railgun,
 		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full),
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(),)
@@ -59,6 +61,49 @@
 	max_ammo()
 
 /obj/vehicle/sealed/mecha/savannah_ivanov/exstasi/populate_parts()
+	cell = new /obj/item/stock_parts/cell/hyper(src)
+	scanmod = new /obj/item/stock_parts/scanning_module/adv(src)
+	capacitor = new /obj/item/stock_parts/capacitor/adv(src)
+	servo = new /obj/item/stock_parts/servo/nano(src)
+	update_part_values()
+
+
+/obj/vehicle/sealed/mecha/durand/tortuga
+	name = "\improper Durand 'Tortuga'"
+	desc = "A heavy defensive powerhouse of a mech. Very slow with a energy shield to deflect all damage from the front, comes with a Ultra AC2 and a impact gernade launcher to flush people out of cover"
+	equip_by_category = list(
+		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
+		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/stringers,
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full),
+		MECHA_POWER = list(),
+		MECHA_ARMOR = list(),)
+
+/obj/vehicle/sealed/mecha/durand/tortuga/Initialize(mapload)
+	. = ..()
+	max_ammo()
+
+/obj/vehicle/sealed/mecha/durand/tortuga/populate_parts()
+	cell = new /obj/item/stock_parts/cell/hyper(src)
+	scanmod = new /obj/item/stock_parts/scanning_module/adv(src)
+	capacitor = new /obj/item/stock_parts/capacitor/adv(src)
+	servo = new /obj/item/stock_parts/servo/nano(src)
+	update_part_values()
+
+/obj/vehicle/sealed/mecha/marauder/horizon
+	name = "\improper Marauder 'Horizon'"
+	desc = "A medium chasis, highly customizable but defualted to long range combat. This one comes with one rapid fire energy weapon to keep enemies off of you and one fast a light beam to deal damage from afar"
+	equip_by_category = list(
+		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/lasershot,
+		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy,
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full),
+		MECHA_POWER = list(),
+		MECHA_ARMOR = list(),)
+
+/obj/vehicle/sealed/mecha/marauder/horizon/Initialize(mapload)
+	. = ..()
+	max_ammo()
+
+/obj/vehicle/sealed/mecha/marauder/horizon/populate_parts()
 	cell = new /obj/item/stock_parts/cell/hyper(src)
 	scanmod = new /obj/item/stock_parts/scanning_module/adv(src)
 	capacitor = new /obj/item/stock_parts/capacitor/adv(src)

--- a/modular_np_lethal/mechs_buffs/code/equipment/gravcata.dm
+++ b/modular_np_lethal/mechs_buffs/code/equipment/gravcata.dm
@@ -1,0 +1,7 @@
+/obj/item/mecha_parts/mecha_equipment/gravcatapult
+	name = "mounted gravitational catapult"
+	desc = "An exosuit mounted Gravitational Catapult."
+	icon_state = "mecha_teleport"
+	equip_cooldown = 60 // This things fucking insane. Made this entire DM to nerf it's fire rate so you can't stunlock literally anyone with a wall
+	energy_drain = 100
+	range = MECHA_MELEE|MECHA_RANGED

--- a/modular_np_lethal/mechs_buffs/code/equipment/mecha_ammo.dm
+++ b/modular_np_lethal/mechs_buffs/code/equipment/mecha_ammo.dm
@@ -1,0 +1,29 @@
+// Creates 3 new ammo boxes that will feed into every weapon that's not a clown/mime, uses pre-defined ammo vars in code.
+// LMG = Ballistic / Flashbang = Non-Lethal / PEP = Explosive
+// it all prints out of the same machine, not like it matters that much, might as well make it easy.
+
+/obj/item/mecha_ammo/lmg/ballistic
+	name = "Ballistic ammo box"
+	desc = "A box of linked ammunition, designed for all ballistic weapons."
+	icon_state = "lmg"
+	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*2)
+	rounds = 300
+	ammo_type = MECHA_AMMO_LMG
+
+/obj/item/mecha_ammo/flashbang/nonlethal
+	name = "Non-lethal ammo box"
+	desc = "A box of non-lethal ammunition, flashbangs, stingbangs and pepperspray"
+	icon_state = "flashbang"
+	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2,/datum/material/gold=SMALL_MATERIAL_AMOUNT*5)
+	rounds = 6
+	ammo_type = MECHA_AMMO_FLASHBANG
+
+/obj/item/mecha_ammo/pep/explosive
+	name = "Explosive ammo box"
+	desc = "A box of large explosives, for explosive weapons."
+	icon_state = "missile_br"
+	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*4,/datum/material/gold=SMALL_MATERIAL_AMOUNT*5)
+	rounds = 6
+	direct_load = TRUE
+	load_audio = 'sound/weapons/gun/general/mag_bullet_insert.ogg'
+	ammo_type = MECHA_AMMO_MISSILE_PEP

--- a/modular_np_lethal/mechs_buffs/code/equipment/module.dm
+++ b/modular_np_lethal/mechs_buffs/code/equipment/module.dm
@@ -1,0 +1,13 @@
+// all the mechs have double the health, therefore this heals faster.
+
+/obj/item/mecha_parts/mecha_equipment/repair_droid
+	name = "exosuit repair droid"
+	desc = "An automated repair droid for exosuits. Scans for damage and repairs it. Can fix almost all types of external or internal damage."
+	icon_state = "repair_droid"
+	energy_drain = 100
+	range = 0
+	can_be_toggled = TRUE
+	active = FALSE
+	equipment_slot = MECHA_UTILITY
+	/// Repaired health per second
+	health_boost = 3

--- a/modular_np_lethal/mechs_buffs/code/mechs/SI.dm
+++ b/modular_np_lethal/mechs_buffs/code/mechs/SI.dm
@@ -1,0 +1,49 @@
+
+/**
+ * ## Savannah-Ivanov!
+ *
+ * A two person mecha that delegates moving to the driver and shooting to the pilot.
+ * ...Hilarious, right?
+ */
+
+//The SI is a powerhouse, similarly as tanky as the durand but able to move at a speed of a gygax. However, of course, it takes two pilots working in synch to use effectivly.
+//All it got was it's stats bumped up.
+/obj/vehicle/sealed/mecha/savannah_ivanov
+	name = "\improper Savannah-Ivanov"
+	desc = "An insanely overbulked mecha that handily crushes single-pilot opponents. The price is that you need two pilots to use it."
+	icon = 'icons/mob/coop_mech.dmi'
+	base_icon_state = "savannah_ivanov"
+	icon_state = "savannah_ivanov_0_0"
+	//does not include mmi compatibility
+	mecha_flags = CAN_STRAFE | IS_ENCLOSED | HAS_LIGHTS
+	mech_type = EXOSUIT_MODULE_SAVANNAH
+	movedelay = 3
+	internal_damage_threshold = 25
+	internal_damage_probability = 10
+	max_integrity = 900 //really tanky, like damn
+	armor_type = /datum/armor/mecha_savannah_ivanov
+	max_temperature = 30000
+	force = 30
+	destruction_sleep_duration = 20
+	exit_delay = 20
+	wreckage = /obj/structure/mecha_wreckage/savannah_ivanov
+	max_occupants = 2
+	max_equip_by_category = list(
+		MECHA_L_ARM = 1,
+		MECHA_R_ARM = 1,
+		MECHA_UTILITY = 3,
+		MECHA_POWER = 1,
+		MECHA_ARMOR = 3,
+	)
+	//no tax on flying, since the power cost is in the leap itself.
+	phasing_energy_drain = 0
+
+/datum/armor/mecha_savannah_ivanov
+	melee = 30
+	bullet = 40
+	laser = 40
+	energy = 30
+	bomb = 15
+	fire = 100
+	acid = 100
+

--- a/modular_np_lethal/mechs_buffs/code/mechs/durand.dm
+++ b/modular_np_lethal/mechs_buffs/code/mechs/durand.dm
@@ -1,0 +1,78 @@
+//The durand is the staple heavy mech. It's slower, even fucking slower then usual. It can deflect all damage with it's shield and it's stats have been moved up to be similar to a vanilla Marauder.
+/obj/vehicle/sealed/mecha/durand
+	desc = "An aging combat exosuit utilized by the Nanotrasen corporation. Originally developed to combat hostile alien lifeforms."
+	name = "\improper Durand"
+	icon_state = "durand"
+	base_icon_state = "durand"
+	movedelay = 5
+	internal_damage_threshold = 35
+	internal_damage_probability = 15
+	max_integrity = 1000
+	accesses = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
+	armor_type = /datum/armor/mecha_durand
+	max_temperature = 30000
+	force = 40
+	destruction_sleep_duration = 20
+	exit_delay = 20
+	wreckage = /obj/structure/mecha_wreckage/durand
+	mech_type = EXOSUIT_MODULE_DURAND
+	max_equip_by_category = list(
+		MECHA_L_ARM = 1,
+		MECHA_R_ARM = 1,
+		MECHA_UTILITY = 3,
+		MECHA_POWER = 1,
+		MECHA_ARMOR = 3,
+	)
+
+
+
+/datum/armor/mecha_durand
+	melee = 40
+	bullet = 45
+	laser = 45
+	energy = 10
+	bomb = 20
+	fire = 100
+	acid = 100
+
+
+//evil durand. This ones funny, it's probably the tankiest thing in the game, it's slow, slower then the durand but over twice as durable
+// it's a big admin boss monster
+
+/obj/vehicle/sealed/mecha/marauder/mauler
+	desc = "Heavy-duty, combat exosuit, developed off of the existing Durand model."
+	movedelay = 5.5
+	name = "\improper Mauler"
+	ui_theme = "syndicate"
+	internal_damage_threshold = 40
+	internal_damage_probability = 10
+	icon_state = "mauler"
+	max_integrity = 3500
+	base_icon_state = "mauler"
+	armor_type = /datum/armor/mecha_mauler
+	wreckage = /obj/structure/mecha_wreckage/mauler
+	mecha_flags = ID_LOCK_ON | CAN_STRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
+	max_equip_by_category = list(
+		MECHA_L_ARM = 1,
+		MECHA_R_ARM = 1,
+		MECHA_UTILITY = 4,
+		MECHA_POWER = 1,
+		MECHA_ARMOR = 4,
+	)
+	equip_by_category = list(
+		MECHA_L_ARM = null,
+		MECHA_R_ARM = null,
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full, /obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_POWER = list(),
+		MECHA_ARMOR = list(),
+	)
+	destruction_sleep_duration = 20
+
+/datum/armor/mecha_mauler
+	melee = 45
+	bullet = 45
+	laser = 45
+	energy = 10
+	bomb = 20
+	fire = 100
+	acid = 100

--- a/modular_np_lethal/mechs_buffs/code/mechs/gygax.dm
+++ b/modular_np_lethal/mechs_buffs/code/mechs/gygax.dm
@@ -1,0 +1,93 @@
+/obj/vehicle/sealed/mecha/gygax
+	desc = "A lightweight, security exosuit. Popular among private and corporate security."
+	name = "\improper Gygax"
+	icon_state = "gygax"
+	base_icon_state = "gygax"
+	movedelay = 3
+	max_integrity = 800
+	internal_damage_threshold = 25
+	internal_damage_probability = 10
+	accesses = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
+	armor_type = /datum/armor/mecha_gygax
+	max_temperature = 25000
+	force = 25
+	destruction_sleep_duration = 20
+	exit_delay = 20
+	wreckage = /obj/structure/mecha_wreckage/gygax
+	mech_type = EXOSUIT_MODULE_GYGAX
+	max_equip_by_category = list(
+		MECHA_L_ARM = 1,
+		MECHA_R_ARM = 1,
+		MECHA_UTILITY = 3,
+		MECHA_POWER = 1,
+		MECHA_ARMOR = 2,
+	)
+	step_energy_drain = 4
+	can_use_overclock = TRUE
+	overclock_safety_available = TRUE
+	overclock_safety = TRUE
+
+/datum/armor/mecha_gygax
+	melee = 30
+	bullet = 20
+	laser = 20
+	energy = 15
+	fire = 100
+	acid = 100
+
+
+//dark gygax, evil gygax. All the evil mechs are balanced to be admin events/boss mechs, they should absolulty smoke you in a 1v1, but team up and work togther and you might just survive
+// In the case of the dark gygax, this things fast. Faster then any mech should be, slightly weaker in structure though. it dies fast.
+
+/obj/vehicle/sealed/mecha/gygax/dark
+	desc = "A lightweight exosuit, painted in a dark scheme. This model appears to have some modifications."
+	name = "\improper Dark Gygax"
+	ui_theme = "syndicate"
+	icon_state = "darkgygax"
+	base_icon_state = "darkgygax"
+	movedelay = 2
+	internal_damage_threshold = 25
+	internal_damage_probability = 10
+	max_integrity = 800
+	armor_type = /datum/armor/gygax_dark
+	max_temperature = 35000
+	overclock_coeff = 4
+	overclock_temp_danger = 30
+	force = 30
+	wreckage = /obj/structure/mecha_wreckage/gygax/dark
+	mecha_flags = ID_LOCK_ON | CAN_STRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
+	max_equip_by_category = list(
+		MECHA_L_ARM = 1,
+		MECHA_R_ARM = 1,
+		MECHA_UTILITY = 4,
+		MECHA_POWER = 1,
+		MECHA_ARMOR = 3,
+	)
+	equip_by_category = list(
+		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot,
+		MECHA_R_ARM = null,
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full, /obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_POWER = list(),
+		MECHA_ARMOR = list(/obj/item/mecha_parts/mecha_equipment/armor/anticcw_armor_booster, /obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster),
+	)
+	destruction_sleep_duration = 40
+
+/datum/armor/gygax_dark
+	melee = 20
+	bullet = 20
+	laser = 20
+	energy = 35
+	bomb = 20
+	fire = 100
+	acid = 100
+
+/obj/vehicle/sealed/mecha/gygax/dark/loaded/Initialize(mapload)
+	. = ..()
+	max_ammo()
+
+/obj/vehicle/sealed/mecha/gygax/dark/loaded/populate_parts()
+	cell = new /obj/item/stock_parts/cell/bluespace(src)
+	scanmod = new /obj/item/stock_parts/scanning_module/triphasic(src)
+	capacitor = new /obj/item/stock_parts/capacitor/quadratic(src)
+	servo = new /obj/item/stock_parts/servo/femto(src)
+	update_part_values()

--- a/modular_np_lethal/mechs_buffs/code/mechs/marauder.dm
+++ b/modular_np_lethal/mechs_buffs/code/mechs/marauder.dm
@@ -1,0 +1,76 @@
+// The marauder is the middle ground between the Durands heavy defensive role and the Gygax's high speed agression. It has extra mod slots to either make it more tanky, or add new features.
+// To achieve this it's armor has been lowerd, and it's health brought up both of these values sit in the middle of the two other mechs. It also moves alot faster.
+
+/obj/vehicle/sealed/mecha/marauder
+	desc = "A medium weight modular exosuit, decently fast on its feed and able to take more then a few hits before going down."
+	name = "\improper Marauder"
+	icon_state = "marauder"
+	base_icon_state = "marauder"
+	movedelay = 4
+	internal_damage_threshold = 25
+	internal_damage_probability = 10
+	max_integrity = 900
+	armor_type = /datum/armor/mecha_marauder
+	max_temperature = 60000
+	destruction_sleep_duration = 10
+	exit_delay = 40
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	accesses = list(ACCESS_CENT_SPECOPS)
+	wreckage = /obj/structure/mecha_wreckage/marauder
+	mecha_flags = CAN_STRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
+	mech_type = EXOSUIT_MODULE_MARAUDER
+	force = 45
+	max_equip_by_category = list(
+		MECHA_L_ARM = 1,
+		MECHA_R_ARM = 1,
+		MECHA_UTILITY = 5,
+		MECHA_POWER = 1,
+		MECHA_ARMOR = 3,
+	)
+	bumpsmash = TRUE
+
+/datum/armor/mecha_marauder
+	melee = 35
+	bullet = 35
+	laser = 35
+	energy = 30
+	bomb = 15
+	fire = 100
+	acid = 100
+
+//Seraph, evil marauder. better in every way, it's probably the most dangerous of all the big dumb evil mechs. All evil mechs are for admin events/big boss fights.
+// It's similar to a durand in it's durability but can walk around the speed of a gygax. Be afraid.
+
+/obj/vehicle/sealed/mecha/marauder/seraph
+	desc = "Heavy-duty, command-type exosuit. This is a custom model, utilized only by high-ranking military personnel."
+	name = "\improper Seraph"
+	icon_state = "seraph"
+	base_icon_state = "seraph"
+	armor_type = /datum/armor/mecha_seraph
+	movedelay = 3
+	internal_damage_threshold = 30
+	internal_damage_probability = 10
+	max_integrity = 1000
+	wreckage = /obj/structure/mecha_wreckage/seraph
+	force = 55
+	max_equip_by_category = list(
+		MECHA_L_ARM = 1,
+		MECHA_R_ARM = 1,
+		MECHA_UTILITY = 5,
+		MECHA_POWER = 1,
+		MECHA_ARMOR = 3,
+	)
+	equip_by_category = list(
+
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full, /obj/item/mecha_parts/mecha_equipment/thrusters/ion),
+		MECHA_POWER = list(),
+		MECHA_ARMOR = list(/obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster),
+	)
+/datum/armor/mecha_seraph
+	melee = 40
+	bullet = 40
+	laser = 40
+	energy = 30
+	bomb = 15
+	fire = 100
+	acid = 100

--- a/modular_np_lethal/mechs_buffs/code/weapons/ballistic_guns.dm
+++ b/modular_np_lethal/mechs_buffs/code/weapons/ballistic_guns.dm
@@ -1,0 +1,77 @@
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
+	name = "\improper LBX AC 10 \"Scattershot\""
+	desc = "A weapon for combat exosuits. Shoots a spread of pellets. Shoots Ballistic Ammo"
+	icon_state = "mecha_scatter"
+	equip_cooldown = 20
+	projectile = /obj/projectile/bullet/scattershot
+	projectiles = 80
+	projectiles_cache = 80
+	projectiles_cache_max = 200
+	projectiles_per_shot = 8
+	variance = 35
+	harmful = TRUE
+	ammo_type = MECHA_AMMO_LMG
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
+	name = "\improper Ultra AC 2"
+	desc = "A weapon for combat exosuits. Shoots a rapid, three shot burst. Shoots Ballistic Ammo"
+	icon_state = "mecha_carbine"
+	equip_cooldown = 15
+	projectile = /obj/projectile/bullet/lmg
+	projectiles = 300
+	projectiles_cache = 300
+	projectiles_cache_max = 1200
+	projectiles_per_shot = 3
+	variance = 1
+	randomspread = 0
+	projectile_delay = 2
+	harmful = TRUE
+	ammo_type = MECHA_AMMO_LMG
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/ac20
+	name = "\improper  LB AC 20 \"Slugger\""
+	desc = "A weapon for combat exosuits. Shoots one massive slug, falls off over range. Shoots Ballistic Ammo"
+	icon_state = "mecha_uac2"
+	equip_cooldown = 25
+	projectile = /obj/projectile/bullet/lmg/ac20b
+	projectiles = 20
+	projectiles_cache = 20
+	projectiles_cache_max = 100
+	projectiles_per_shot = 1
+	variance = 0
+	randomspread = 0
+	projectile_delay = 1
+	harmful = TRUE
+	ammo_type = MECHA_AMMO_LMG
+	fire_sound = 'sound/weapons/gun/hmg/hmg.ogg'
+
+//nerfing this thing via slower fire rate
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine
+	name = "\improper FNX-99 \"Hades\" Carbine"
+	desc = "A weapon for combat exosuits. Shoots Ballistic ammo."
+	icon_state = "mecha_carbine"
+	equip_cooldown = 50
+	projectile = /obj/projectile/bullet/incendiary/fnx99
+	projectiles = 24
+	projectiles_cache = 24
+	projectiles_cache_max = 96
+	harmful = TRUE
+	ammo_type = MECHA_AMMO_LMG
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/railgun
+	name = "\improper  ARLS-500 \"Piercer\""
+	desc = "A weapon for combat exosuits. Magnetically fires a metallic rod at a high speed, prone to peircing armor and embedding. Requires a manual reload of the rail between each shot. Shoots Ballistic Ammo "
+	icon_state = "mecha_mime"
+	fire_sound = "sound/weapons/emitter2.ogg"
+	equip_cooldown = 30
+	projectile = /obj/projectile/bullet/rebar/r500
+	projectiles = 1
+	projectiles_cache = 30
+	projectiles_cache_max = 100
+	projectiles_per_shot = 1
+	variance = 0
+	randomspread = 0
+	harmful = TRUE
+	ammo_type = MECHA_AMMO_LMG

--- a/modular_np_lethal/mechs_buffs/code/weapons/energy_guns.dm
+++ b/modular_np_lethal/mechs_buffs/code/weapons/energy_guns.dm
@@ -1,0 +1,40 @@
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/lasershot
+	equip_cooldown = 30
+	name = "\improper LK-T5 \"Flare\" laser shot"
+	desc = "A weapon for combat exosuits. Shoots beams of light, slow fire rate, hits almost instantly. Drains alot of power, best used at longer consistant ranges."
+	icon_state = "mecha_laser"
+	energy_drain = 50000
+	projectile = /obj/projectile/beam/laser/hitlaser
+	fire_sound = 'sound/weapons/beam_sniper.ogg'
+	harmful = TRUE
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
+	equip_cooldown = 2
+	name = "\improper CH-PS \"Immolator\" laser"
+	desc = "A weapon for combat exosuits. Shoots basic rapid lasers."
+	icon_state = "mecha_laser"
+	energy_drain = 10
+	projectile = /obj/projectile/beam/laser/lethallaser
+	fire_sound = 'sound/weapons/laser.ogg'
+	harmful = TRUE
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
+	equip_cooldown = 30
+	name = "\improper CH-LC \"Solaris\" laser cannon"
+	desc = "A weapon for combat exosuits. Shoots heavy lasers."
+	icon_state = "mecha_ion"
+	energy_drain = 100
+	projectile = /obj/projectile/beam/laser/heavy/lethalheavy
+	fire_sound = 'sound/weapons/lasercannonfire.ogg'
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/trickshot
+	equip_cooldown = 30
+	name = "\improper ZE-TRON \"Trickshooter\" laser beam"
+	desc = "A weapon for combat exosuits. A dangerously modfied version of the Flare, does less inital damage with each shit but will gain damage as the beam refractors with each richoete, bounces 3 times.."
+	icon_state = "mecha_ion"
+	energy_drain = 20000
+	projectile = /obj/projectile/bullet/lmg/tricklaser
+	fire_sound = 'sound/weapons/beam_sniper.ogg'
+	harmful = TRUE

--- a/modular_np_lethal/mechs_buffs/code/weapons/launchers.dm
+++ b/modular_np_lethal/mechs_buffs/code/weapons/launchers.dm
@@ -1,0 +1,45 @@
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/stringers
+	name = "\improper SGL-8 stingbang grenade launcher"
+	desc = "A weapon for combat exosuits, launches primed stingbangs, uses flashbang ammo."
+	icon_state = "mecha_grenadelnchr"
+	projectile = /obj/item/grenade/stingbang
+	fire_sound = 'sound/weapons/gun/general/grenade_launch.ogg'
+	projectiles = 6
+	projectiles_cache = 6
+	projectiles_cache_max = 24
+	missile_speed = 1.5
+	equip_cooldown = 60
+	ammo_type = MECHA_AMMO_FLASHBANG
+	det_time = 20
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/clusterbang/impactlauncher //Evil ass gun
+	name = "\improper IPS-7 impact gernade launcher"
+	desc = "A weapon for combat exosuits. Launches primed impact gernades. You monster."
+	projectiles = 6
+	projectiles_cache = 0
+	projectiles_cache_max = 0
+	disabledreload = TRUE
+	projectile = /obj/item/grenade/frag/impact
+	equip_cooldown = 90
+	ammo_type = MECHA_AMMO_MISSILE_PEP
+
+
+
+
+
+
+// Untouched launchers, just changing their ammo to the generic 'Explosive.'
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
+	name = "\improper SRM-8 missile rack"
+	desc = "A weapon for combat exosuits. Launches short range missiles."
+	icon_state = "mecha_missilerack"
+	projectile = /obj/projectile/bullet/rocket/srm
+	fire_sound = 'sound/weapons/gun/general/rocket_launch.ogg'
+	projectiles = 8
+	projectiles_cache = 0
+	projectiles_cache_max = 0
+	disabledreload = TRUE
+	equip_cooldown = 60
+	harmful = TRUE
+	ammo_type = MECHA_AMMO_MISSILE_PEP

--- a/modular_np_lethal/mechs_buffs/code/weapons/melee.dm
+++ b/modular_np_lethal/mechs_buffs/code/weapons/melee.dm
@@ -1,0 +1,110 @@
+// Mech saw, it's a drill that winds up really fast and does less damage. Funny way to kill people stam critted, and maybe get 20ish damage in in a real fight.
+// Most the code is here to rename all it's actions/change the sounds effect to the saw. It still works on terrain but I think that's fine. Big ass saw can cut through walls.
+
+/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill/mechsaw
+	name = "Exosuit-Sized Chainsaw"
+	desc = "Jagged rusty chainsaw sized for exosuits, you get the idea you know what this is for."
+	icon_state = "chainsaw_off"
+	icon = 'icons/obj/weapons/chainsaw.dmi'
+	equip_cooldown = 1
+	drill_delay = 1.5
+	force = 7
+	toolspeed = 10
+
+
+/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill/mechsaw/drill_mob(mob/living/target, mob/living/user)
+	target.visible_message(span_danger("[chassis] is sawing [target] with [src]!"), \
+						span_userdanger("[chassis] is sawing you with [src]!"))
+	log_combat(user, target, "sawed", "[name]", "Combat mode: [user.combat_mode ? "On" : "Off"])(DAMTYPE: [uppertext(damtype)])")
+	if(target.stat == DEAD && target.getBruteLoss() >= (target.maxHealth * 2))
+		log_combat(user, target, "gibbed", name)
+		if(LAZYLEN(target.butcher_results) || LAZYLEN(target.guaranteed_butcher_results))
+			SEND_SIGNAL(src, COMSIG_MECHA_DRILL_MOB, chassis, target)
+		else
+			target.investigate_log("has been gibbed by [src] (attached to [chassis]).", INVESTIGATE_DEATHS)
+			target.gib(DROP_ALL_REMAINS)
+	else
+		//drill makes a hole
+		var/obj/item/bodypart/target_part = target.get_bodypart(target.get_random_valid_zone(BODY_ZONE_CHEST))
+		target.apply_damage(7, BRUTE, BODY_ZONE_CHEST, target.run_armor_check(target_part, MELEE))
+
+		//blood splatters
+		var/splatter_dir = get_dir(chassis, target)
+		if(isalien(target))
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target.drop_location(), splatter_dir)
+		else
+			new /obj/effect/temp_visual/dir_setting/bloodsplatter(target.drop_location(), splatter_dir)
+
+		//organs go everywhere
+		if(target_part && prob(10 * drill_level))
+			target_part.dismember(BRUTE)
+
+
+
+/obj/item/mecha_parts/mecha_equipment/drill/diamonddrill/mechsaw/action(mob/source, atom/target, list/modifiers, bumped)
+	//If bumped, only bother drilling mineral turfs
+	if(bumped)
+		if(!ismineralturf(target))
+			return
+
+		//Prevent drilling into gibtonite more than once; code mostly from MODsuit drill
+		if(istype(target, /turf/closed/mineral/gibtonite))
+			var/turf/closed/mineral/gibtonite/giberal_turf = target
+			if(giberal_turf.stage != GIBTONITE_UNSTRUCK)
+				playsound(chassis, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+				to_chat(source, span_warning("[icon2html(src, source)] Active gibtonite ore deposit detected! Safety protocols preventing continued drilling."))
+				return
+
+	else
+		// We can only drill non-space turfs, living mobs and objects.
+		if(isspaceturf(target) || !(isliving(target) || isobj(target) || isturf(target)))
+			return
+
+		// For whatever reason we can't drill things that acid won't even stick too, and probably
+		// shouldn't waste our time drilling indestructible things.
+		if(isobj(target))
+			var/obj/target_obj = target
+			if(target_obj.resistance_flags & (UNACIDABLE | INDESTRUCTIBLE))
+				return
+
+	// You can't drill harder by clicking more.
+	if(DOING_INTERACTION_WITH_TARGET(source, target) && do_after_cooldown(target, source, DOAFTER_SOURCE_MECHADRILL))
+		return
+
+	target.visible_message(span_warning("[chassis] starts to saw [target]!"), \
+				span_userdanger("[chassis] starts to saw [target]!!!"), \
+				span_hear("You hear sawing."))
+
+	log_message("Started sawing [target]", LOG_MECHA)
+
+	// Drilling a turf is a one-and-done procedure.
+	if(isturf(target))
+		// Check if we can even use the equipment to begin with.
+		if(!action_checks(target))
+			return
+
+		var/turf/T = target
+		T.drill_act(src, source)
+
+		return ..()
+
+	// Drilling objects and mobs is a repeating procedure.
+	while(do_after_mecha(target, source, drill_delay))
+		if(isliving(target))
+			drill_mob(target, source)
+			playsound(src,'sound/weapons/chainsawhit.ogg',40,TRUE)
+		else if(isobj(target))
+			var/obj/O = target
+			if(istype(O, /obj/item/boulder))
+				var/obj/item/boulder/nu_boulder = O
+				nu_boulder.manual_process(src, source)
+			else
+				O.take_damage(20, BRUTE, 0, FALSE, get_dir(chassis, target))
+			playsound(src,'sound/weapons/chainsawhit.ogg', 40, TRUE)
+
+		// If we caused a qdel drilling the target, we can stop drilling them.
+		// Prevents starting a do_after on a qdeleted target.
+		if(QDELETED(target))
+			break
+
+	return ..()

--- a/modular_np_lethal/mechs_buffs/code/weapons/projectiles.dm
+++ b/modular_np_lethal/mechs_buffs/code/weapons/projectiles.dm
@@ -1,0 +1,99 @@
+//default mech laser
+
+/obj/projectile/beam/laser/lethallaser
+	tracer_type = /obj/effect/projectile/tracer/laser
+	muzzle_type = /obj/effect/projectile/muzzle/laser
+	impact_type = /obj/effect/projectile/impact/laser
+	damage = 15
+
+//mech heavy laser
+
+/obj/projectile/beam/laser/heavy/lethalheavy
+	damage = 65
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/yellow_laser
+	speed = 0.5
+	light_range = 2
+	light_color = COLOR_RED
+	wound_falloff_tile = 0.1
+
+
+//default mech ac2 shot
+/obj/projectile/bullet/lmg
+	damage = 25
+	armour_penetration = 5
+
+
+// lbx pellet mechs
+/obj/projectile/bullet/scattershot
+	icon_state = "pellet"
+	damage = 15
+	range = 12
+	damage_falloff_tile = -0.10
+
+
+//mech ac20
+/obj/projectile/bullet/lmg/ac20b
+	damage = 120
+	damage_falloff_tile = -0.1
+	speed = 2
+	icon_state = "cannonball"
+
+
+//mech hitscan laser
+/obj/projectile/beam/laser/hitlaser
+	damage = 50
+
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/yellow_laser
+	hitscan = TRUE
+	hitscan_light_intensity = 3
+	hitscan_light_range = 0.75
+	hitscan_light_color_override = COLOR_RED
+
+
+
+//scuffed ass trickshot """"laser"""""
+/obj/projectile/bullet/lmg/tricklaser
+	damage = 30
+	range = 200
+	hitscan = TRUE
+	hitscan_light_intensity = 2
+	hitscan_light_range = 0.75
+	ricochets_max = 3
+	ricochet_chance = 200
+	ricochet_auto_aim_angle = 30
+	ricochet_auto_aim_range = 5
+	ricochet_decay_damage = 2
+	ricochet_decay_chance = 1
+	icon_state = "u_laser"
+	tracer_type = /obj/effect/projectile/tracer/laser/blue
+	muzzle_type = /obj/effect/projectile/muzzle/laser/blue
+	impact_type = /obj/effect/projectile/impact/laser/blue
+	hitscan_light_color_override = COLOR_BLUE_LIGHT
+	ricochet_shoots_firer = TRUE
+
+
+// mech rebar railgun
+/obj/projectile/bullet/rebar/r500
+	name = "rebar"
+	icon_state = "rebar"
+	damage = 80
+	speed = 0.3
+	armour_penetration = 10
+	wound_bonus = -20
+	bare_wound_bonus = 20
+	embedding = list(embed_chance=60, fall_chance=2, jostle_chance=2, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=3, jostle_pain_mult=2, rip_time=10)
+	embed_falloff_tile = -5
+	wound_falloff_tile = -2
+	shrapnel_type = /obj/item/stack/rods
+	light_range = 2
+	light_color = COLOR_YELLOW
+
+ // PEP missles, getting a slight buff to organic damage anbd now they uh, actually explode on walls.
+/obj/projectile/bullet/rocket/pep
+	name = "precise explosive missile"
+	desc = "Human friendly, metal unfriendly."
+	icon_state = "low_yield_rocket"
+	damage = 40
+	anti_armour_damage = 80 //Doesn't (probably) kill borgs in one shot, but it will hurt
+	random_crits_enabled = FALSE //yeah, no
+


### PR DESCRIPTION
_PLEASEGODWORK_

The great Dente V github skill issue comes to its final arc, with a not fucked up pr.

I wrote a big description here like 5 times so here we go last time.

All combat mechs are tankier, the marauder is unadmined and now is an in-between of the gygax and durand. The durand is even slower. 

Most weapons got reworked, and a few new ones got added. 

Mech ammo now takes 1 of 3 generic types, ballistic, non-lethal (heh), and explosive.

Mechs no longer stun you on punch. 

Adds two new mechs to the mech beacon, meaning every available mech is now there. 

Everything should be decently commented (I'm sorry) 


![How2mech](https://github.com/LethalStation/NovaSector/assets/106217024/5290385a-7436-4bb7-ad58-ac0fa2a85d35)
