### PR TITLE
The Hand Job: Working cyborg hands

### DIFF
--- a/modular_np_lethal/cyborg_hands/code/cyborg_hands.dm
+++ b/modular_np_lethal/cyborg_hands/code/cyborg_hands.dm
@@ -1,0 +1,77 @@
+// Lets cyborgs pick stuff up, and outlines stuff that isn't in their model's kit for easier identification.
+// Anything they pick up can be used like normal. Retains all of its functionality. ALL of it. Balance nightmare? Yes
+
+/obj/item/attack_ai(mob/user)
+	if(Adjacent(user, src) && !istype(src.loc, /obj/item/robot_model) && iscyborg(user)) // it's not one of our modules, and we're 100% sure we're a cyborg
+		var/mob/living/silicon/robot/robor = user
+
+		// determine the appropriate hand index we can use for this, by checking held_items to see what modules are empty
+		var/can_pickup = FALSE
+		for (var/module_slot in 1 to length(robor.held_items))
+			if(!robor.held_items[module_slot])
+				robor.active_hand_index = module_slot
+				can_pickup = TRUE
+				break
+
+		if (!can_pickup)
+			balloon_alert(robor, "no modules free to pick up with!")
+			return
+
+		if(robor.low_power_mode)
+			balloon_alert(robor, "no power: hand actuators disabled!")
+			return
+
+		if (robor.is_invalid_module_number(robor.active_hand_index))
+			balloon_alert(robor, "module too damaged: seek repairs!")
+			return
+
+		if (!attempt_pickup(user))
+			robor.select_module(robor.active_hand_index) // set it to active because you know, we probably want to use it
+			SET_PLANE_EXPLICIT(src, ABOVE_HUD_PLANE, src) // so we can see the stupid thing on the HUD
+			AddComponent(/datum/component/cyborg_hand_item, host = robor) // link up our component for outline + other handling
+			robor.hud_used.persistent_inventory_update() // so it shows up on the HUD at all
+			robor.observer_screen_update(src, TRUE) // so ghosts see it via observer overlay
+		return
+
+	return ..()
+
+/mob/living/silicon/put_in_hand_check()
+	return TRUE // unbelievable, stupendous, excellent, a paragon of coding prowess
+
+/mob/living/silicon/robot/select_module()
+	..()
+
+	var/mod_index = get_selected_module()
+	active_hand_index = !mod_index ? 1 : mod_index
+
+/mob/living/silicon/robot/unequip_module_from_slot(obj/item/item_module, module_num)
+	// we're dropping an item that we picked up. normally this runtimes, but clearly we don't want that, we just want to drop the stupid item.
+	// look this sucks and there's code duplication involved here but it'd be semi-modular otherwise
+	if(!(item_module in model.modules))
+		dropItemToGround(item_module)
+
+		if(client)
+			client.screen -= item_module
+
+		if(module_active == item_module)
+			module_active = null
+
+		switch(module_num)
+			if(BORG_CHOOSE_MODULE_ONE)
+				if(!(disabled_modules & BORG_MODULE_ALL_DISABLED))
+					inv1.icon_state = initial(inv1.icon_state)
+			if(BORG_CHOOSE_MODULE_TWO)
+				if(!(disabled_modules & BORG_MODULE_TWO_DISABLED))
+					inv2.icon_state = initial(inv2.icon_state)
+			if(BORG_CHOOSE_MODULE_THREE)
+				if(!(disabled_modules & BORG_MODULE_THREE_DISABLED))
+					inv3.icon_state = initial(inv3.icon_state)
+
+		hud_used.persistent_inventory_update()
+		observer_screen_update(item_module, FALSE)
+		return
+
+	return ..()
+
+/mob/living/silicon/robot/can_hold_items(obj/item/I)
+	return ..()

--- a/modular_np_lethal/cyborg_hands/code/outline_element.dm
+++ b/modular_np_lethal/cyborg_hands/code/outline_element.dm
@@ -1,0 +1,34 @@
+#define CYBORG_PICKED_UP_FILTER "cyborg_pickup"
+
+/// Cheap component that handles extra behavior for cyborg items, like an outline, or properly resetting modules if they're dropped
+/datum/component/cyborg_hand_item
+	var/outline_colour = "#fcff00"
+	/// The cyborg that's actually holding us
+	var/datum/weakref/holding_robot
+
+/datum/component/cyborg_hand_item/Initialize(mob/living/silicon/robot/host)
+	if (!isitem(parent) || !iscyborg(host))
+		return COMPONENT_INCOMPATIBLE
+
+	holding_robot = WEAKREF(host)
+	var/obj/item/thing = parent
+	RegisterSignal(thing, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(before_unequip))
+	RegisterSignal(thing, COMSIG_ITEM_DROPPED, PROC_REF(on_dropped))
+	thing.add_filter(CYBORG_PICKED_UP_FILTER, 9, list("type" = "outline", "color" = outline_colour, "size" = 1))
+
+/datum/component/cyborg_hand_item/proc/before_unequip(obj/item/thing)
+	SIGNAL_HANDLER
+
+	// clear our module here since we just dropped the item to avoid shenanigans
+	// looks jank, but the other alternative is a low-level /mob proc and NOBODY wants that
+	var/mob/living/silicon/robot/robor = holding_robot.resolve()
+	if (robor.module_active == thing)
+		robor.deselect_module(robor.active_hand_index)
+
+/datum/component/cyborg_hand_item/proc/on_dropped(obj/item/dropped_outlined_thing)
+	SIGNAL_HANDLER
+
+	dropped_outlined_thing.remove_filter(CYBORG_PICKED_UP_FILTER)
+	qdel()
+
+#undef CYBORG_PICKED_UP_FILTER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8352,6 +8352,8 @@
 #include "modular_np_lethal\armor_but_cool\code\armor_types\paper.dm"
 #include "modular_np_lethal\armor_but_cool\code\armor_types\ultra_larp.dm"
 #include "modular_np_lethal\clothing_edits\gear_harness_change.dm"
+#include "modular_np_lethal\cyborg_hands\code\cyborg_hands.dm"
+#include "modular_np_lethal\cyborg_hands\code\outline_element.dm"
 #include "modular_np_lethal\deepmaint_stuff\code\areas_n_shit.dm"
 #include "modular_np_lethal\deepmaint_stuff\code\blow_up_interlink_spawnpoints.dm"
 #include "modular_np_lethal\deepmaint_stuff\code\entrance_and_exit.dm"


### PR DESCRIPTION
## About The Pull Request

Happy pride month!

Cyborgs, unsurprisingly, don't normally have hands.

There's a whole bunch of reasons why this is the case (all-access, remote electronics access, harder to kill, don't suffer wounds or slowdowns) and there's also like five years of /tg/ stigma about cyborgs being overpowered even without them.

I'm not here to contest those reasons. I wanted to give cyborgs hands because a good friend of mine cyborg mains and wishes she could play a cyborg with in-game mechanic-supported hands, so now she gets to. We'll see how things pan out.

The way this works is simple: each cyborg module slot is considered like a hand by the game. When picking something up, the game will try to find the lowest-numbered module that you don't have filled with something else, and it'll put the item you pick up there with a yellow outline.

If your modules are disabled for any reason, you'll drop what you're holding. Anything that otherwise causes modules to undeploy will cause you to drop things. No, there's no in-hand sprites for anything.

You can use any item this way the same way anyone else with hands can. Guns? Go for it. Wizard staves? Sure. I'm bound to have missed some edge cases but like 90% of the things in the game should work and anything that doesn't I'll fix.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

https://github.com/LethalStation/NovaSector/assets/966289/ed449c5e-16a6-441d-9cb4-9da6c1140bac

https://github.com/LethalStation/NovaSector/assets/966289/496178a6-5877-4f88-933a-7952b85b5e76

</details>

## Changelog

:cl: yooriss
balance: Cyborgs can now use module slots as if they were hands, picking up items off the ground and using them like human crew would.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
