### PR TITLE
Remove disposals system damage

### DIFF
--- a/modular_nova/modules/hurtsposals/code/pipe.dm
+++ b/modular_nova/modules/hurtsposals/code/pipe.dm
@@ -1,4 +1,5 @@
 // Make disposal pipes hurt you if you ride them.
+/*
 
 /obj/structure/disposalpipe
 	/// Whether a disposal pipe will hurt if a person changes direction. `FALSE` for hurting, `TRUE` to prevent making them hurt.
@@ -22,4 +23,4 @@
 			continue
 		if(HAS_TRAIT(living_within, TRAIT_TRASHMAN))
 			continue
-		living_within.adjustBruteLoss(5)
+		living_within.adjustBruteLoss(5)*/


### PR DESCRIPTION
## About The Pull Request

Tubes go brrr. It was stupid that they dealt damage, now they don't.

## Changelog

:cl: yooriss
del: Disposals no longer kills you until you die.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
