### PR TITLE
Add automatic whitelist refreshing subsystem

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -136,6 +136,7 @@
 #define INIT_ORDER_DBCORE 95
 #define INIT_ORDER_BLACKBOX 94
 #define INIT_ORDER_SERVER_MAINT 93
+#define INIT_ORDER_WHITELIST 92 // LETHAL EDIT ADDITION - automatic whitelist refresh
 #define INIT_ORDER_PLAYER_RANKS 86 // NOVA EDIT ADDITION - Player Ranks Subsystem
 #define INIT_ORDER_INPUT 85
 #define INIT_ORDER_ADMIN_VERBS 84 // needs to be pretty high, admins cant do much without it

--- a/modular_np_lethal/administration/code/whitelisting.dm
+++ b/modular_np_lethal/administration/code/whitelisting.dm
@@ -1,0 +1,11 @@
+SUBSYSTEM_DEF(whitelisting)
+	name = "Auto-Whitelist"
+	init_order = INIT_ORDER_WHITELIST
+	runlevels = RUNLEVEL_SETUP | RUNLEVEL_LOBBY | RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	wait = 5 MINUTES
+
+/datum/controller/subsystem/whitelisting/Initialize()
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/whitelisting/fire(resumed = FALSE)
+	load_whitelist() // yep that's it

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8358,6 +8358,7 @@
 #include "modular_nova\modules\xenos_nova_redo\code\xeno_types\sentinel.dm"
 #include "modular_nova\modules\xenos_nova_redo\code\xeno_types\spitter.dm"
 #include "modular_nova\modules\xenos_nova_redo\code\xeno_types\warrior.dm"
+#include "modular_np_lethal\administration\code\whitelisting.dm"
 #include "modular_np_lethal\armor_but_cool\code\armor_damage_by_bullets.dm"
 #include "modular_np_lethal\armor_but_cool\code\armor_edits.dm"
 #include "modular_np_lethal\armor_but_cool\code\armor_types\filtre_armor.dm"


### PR DESCRIPTION
Part of administration tooling to avoid a host with adv proc call privileges needing to log on every time we whitelist someone.