### PR TITLE
Fix cyborg atom_storage handling issue

### DIFF
--- a/modular_np_lethal/cyborg_hands/code/outline_element.dm
+++ b/modular_np_lethal/cyborg_hands/code/outline_element.dm
@@ -13,22 +13,40 @@
 	holding_robot = WEAKREF(host)
 	var/obj/item/thing = parent
 	RegisterSignal(thing, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(before_unequip))
+	RegisterSignal(thing, COMSIG_ITEM_STORED, PROC_REF(on_stored))
 	RegisterSignal(thing, COMSIG_ITEM_DROPPED, PROC_REF(on_dropped))
 	thing.add_filter(CYBORG_PICKED_UP_FILTER, 9, list("type" = "outline", "color" = outline_colour, "size" = 1))
+
+/datum/component/cyborg_hand_item/proc/clear_module(forced = FALSE)
+	// clear the cyborg's module here since we just dropped the item to avoid shenanigans
+	// looks jank, but the other alternative is a low-level /mob proc and NOBODY wants that
+	var/obj/item/thing = parent
+	var/mob/living/silicon/robot/robor = holding_robot.resolve()
+	if (forced || robor.module_active == thing)
+		robor.deselect_module(robor.active_hand_index)
+	if (forced)
+		robor.hud_used.persistent_inventory_update()
+
+/datum/component/cyborg_hand_item/proc/cleanup()
+	var/obj/item/thing = parent
+	thing.remove_filter(CYBORG_PICKED_UP_FILTER)
+	qdel()
 
 /datum/component/cyborg_hand_item/proc/before_unequip(obj/item/thing)
 	SIGNAL_HANDLER
 
-	// clear our module here since we just dropped the item to avoid shenanigans
-	// looks jank, but the other alternative is a low-level /mob proc and NOBODY wants that
-	var/mob/living/silicon/robot/robor = holding_robot.resolve()
-	if (robor.module_active == thing)
-		robor.deselect_module(robor.active_hand_index)
+	clear_module()
+
+/datum/component/cyborg_hand_item/proc/on_stored(obj/item/thing)
+	SIGNAL_HANDLER
+	// we want to both clear the module and then cleanup
+
+	clear_module(forced = TRUE)
+	cleanup()
 
 /datum/component/cyborg_hand_item/proc/on_dropped(obj/item/dropped_outlined_thing)
 	SIGNAL_HANDLER
-
-	dropped_outlined_thing.remove_filter(CYBORG_PICKED_UP_FILTER)
-	qdel()
+	clear_module() //just to be like, extra sure, i guess?
+	cleanup()
 
 #undef CYBORG_PICKED_UP_FILTER


### PR DESCRIPTION
## About The Pull Request

Internetizen on Nova's devcont channel raised a pretty severe bug with cyborg hands where they'd lock modules and keep a lingering module_held reference when putting held tools into storage objects.

This fixes that and ensures proper UI behavior, as well. Also some code de-duplication on the component used to handle all this.

## Proof of Testing

https://github.com/LethalStation/NovaSector/assets/966289/189ec697-bd14-4e6b-8a81-9793e5d72bc1

## Changelog

:cl: yooriss
fix: Cyborgs can now put things in containers without having module locking issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
