### PR TITLE
Daughters of Mars: Genemodded quirk for roundstart genetic powers

### DIFF
--- a/modular_np_lethal/genemod_quirk/code/genemod_quirk.dm
+++ b/modular_np_lethal/genemod_quirk/code/genemod_quirk.dm
@@ -1,0 +1,59 @@
+/datum/quirk/genemodded
+	name = "Genemodded"
+	desc = "Some aspect of your physiology has been modified from your race's ordinary baseline, granting you a mutation of your choice."
+	gain_text = span_notice("Your body feels unusual...")
+	lose_text = span_notice("Normality returns in a flash.")
+	value = 10
+	icon = FA_ICON_DNA
+	var/datum/mutation/human/added_mutation = NONE
+
+/datum/quirk/genemodded/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	var/desired_mutation = client_source?.prefs.read_preference(/datum/preference/choiced/genemodded_dna)
+
+	if (desired_mutation)
+		added_mutation = GLOB.possible_genemods_for_quirk[desired_mutation]
+		if (!human_holder.dna.activate_mutation(added_mutation))
+			human_holder.dna.add_mutation(added_mutation, MUT_EXTRA)
+
+/datum/quirk/genemodded/remove()
+	if (added_mutation)
+		var/mob/living/carbon/human/human_holder = quirk_holder
+		human_holder.dna.remove_mutation(added_mutation)
+		added_mutation = null
+
+/datum/quirk_constant_data/genemodded
+	associated_typepath = /datum/quirk/genemodded
+	customization_options = list(/datum/preference/choiced/genemodded_dna)
+
+/datum/preference/choiced/genemodded_dna
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "genemodded_dna"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/proc/generate_genemod_quirk_list()
+	var/list/genemods = list()
+	for (var/datum/mutation/human/mut as anything in subtypesof(/datum/mutation/human))
+		if (!mut.locked)
+			genemods[mut.name] = mut
+
+	return genemods
+
+GLOBAL_LIST_INIT(possible_genemods_for_quirk, generate_genemod_quirk_list())
+
+/datum/preference/choiced/genemodded_dna/init_possible_values()
+	return assoc_to_keys(GLOB.possible_genemods_for_quirk)
+
+/datum/preference/choiced/genemodded_dna/create_default_value()
+	return pick(assoc_to_keys(GLOB.possible_genemods_for_quirk))
+
+/datum/preference/choiced/genemodded_dna/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Genemodded" in preferences.all_quirks
+
+/datum/preference/choiced/genemodded_dna/apply_to_human(mob/living/carbon/human/target, value)
+	return
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8431,6 +8431,7 @@
 #include "modular_np_lethal\epic_loot\code\loot_structures\toolbox.dm"
 #include "modular_np_lethal\epic_loot\code\loot_structures\wall_jackets.dm"
 #include "modular_np_lethal\epic_loot\code\storage_containers\containers.dm"
+#include "modular_np_lethal\genemod_quirk\code\genemod_quirk.dm"
 #include "modular_np_lethal\knee_pads\code\knee_pads.dm"
 #include "modular_np_lethal\lethalguns\code\bullets.dm"
 #include "modular_np_lethal\lethalguns\code\giant_weapon_buff_real.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/genemodded.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/nova/genemodded.tsx
@@ -1,0 +1,10 @@
+// THIS IS A NOVA SECTOR UI FILE
+import {
+  FeatureChoiced,
+} from '../../base';
+import { FeatureDropdownInput } from '../../dropdowns';
+
+export const genemodded_dna: FeatureChoiced = {
+  name: 'Mutation',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request

Very straightforward: adds a 10pt positive quirk that allows you to pick any **one** normal genetics power. Normal in this case refers to 'unlocked' mutations, such as everything that doesn't require mutation combination or is granted by things like wizard spells or the DNA vault.

Note: this also includes the *disadvantage* mutations as well. Why would you want to do this? Some of them are funny, and some of them even have pretty nice bonuses behind some management requirements (like fiery sweat, which is a 50% burn damage reduction).

## Proof of Testing

![](https://puu.sh/K8KdJ/2a29af8b42.png)

## Changelog

:cl: yooriss
add: The Genemodded quirk is now available, allowing you to start the round with a basic genetic mutation of your choice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
