### PR TITLE
Adds the seraph to sec 9

### DIFF
--- a/modular_np_lethal/deepmaint_stuff/code/trade_station_types/gear_filtre.dm
+++ b/modular_np_lethal/deepmaint_stuff/code/trade_station_types/gear_filtre.dm
@@ -13,6 +13,7 @@
 		/datum/crafting_bench_recipe_real/breaching_weapons_drop_pod,
 		/datum/crafting_bench_recipe_real/explosives_drop_pod,
 		/datum/crafting_bench_recipe_real/turret_drop_pod,
+		/datum/crafting_bench_recipe_real/filtre_exosuit
 	)
 
 /obj/structure/epic_loot_crafting_bench/gear_filtre/examine_more(mob/user)
@@ -23,6 +24,7 @@
 	. += span_notice("<b>2</b> ID cards = <b>1</b> breaching weapon beacon")
 	. += span_notice("<b>3</b> ID cards = <b>1</b> point defense weapon beacon")
 	. += span_notice("<b>4</b> ID cards = <b>1</b> explosive support weapon beacon")
+	. += span_notice("<b>8</b> ID cards = <b>1</b> exosuit support beacon")
 	return .
 
 /// Drop pod callers
@@ -61,3 +63,12 @@
 		/obj/item/card/id/advanced = 4,
 	)
 	resulting_item = /obj/item/choice_beacon/filtre/rocket
+
+//evil dente addition of the filtre mech
+
+/datum/crafting_bench_recipe_real/filtre_exosuit
+	recipe_name = "exosuit support beacon"
+	recipe_requirements = list(
+		/obj/item/card/id/advanced = 8,
+	)
+	resulting_item = /obj/item/choice_beacon/mecha/filtre

--- a/modular_np_lethal/loadout_items/mech_beacon.dm
+++ b/modular_np_lethal/loadout_items/mech_beacon.dm
@@ -116,3 +116,53 @@
 	capacitor = new /obj/item/stock_parts/capacitor/adv(src)
 	servo = new /obj/item/stock_parts/servo/nano(src)
 	update_part_values()
+
+// evil filtre mech beacon
+
+/obj/item/choice_beacon/mecha/filtre
+	name = "Filtre Exosuit Deployment Beacon"
+	icon = 'icons/obj/antags/gang/cell_phone.dmi'
+	icon_state = "phone_off"
+	desc = "Owing to the expense of deploying exosuit fleets it has become common practice to field pilots ahead of their vehicles. \
+	Long range communication and beacon devices are used to coordinate the timely delivery of their mechs."
+	company_source = "Ahkter Frontier Corps Exosuit Support Team"
+	company_message = span_bold("Pilot coordinates received. War Machine inbound.")
+
+/obj/item/choice_beacon/mecha/can_use_beacon(mob/living/user)
+	var/area/our_area = get_area(src)
+	if((istype(our_area, /area/gakster_location/hideout_real)) || (istype(our_area, /area/gakster_location/filtre_spawn)))
+		balloon_alert(user, "cannot deploy in hideout")
+		return FALSE
+	return ..()
+
+/obj/item/choice_beacon/mecha/generate_display_names()
+	var/static/list/exosuit_packs
+	if(!exosuit_packs)
+		exosuit_packs = list()
+		var/list/possible_exosuit_packs = list(
+			/obj/vehicle/sealed/mecha/marauder/seraph/firewall
+
+		)
+		for(var/obj/vehicle/sealed/mecha/exosuit_pack as anything in possible_exosuit_packs)
+			exosuit_packs[initial(exosuit_pack.name)] = exosuit_pack
+	return exosuit_packs
+
+
+/obj/vehicle/sealed/mecha/marauder/seraph/firewall
+	name = "\improper Seraph 'Firewall'"
+	desc = "A top of the line, high firepower mech built for all ranges, comes pre-eqiupped with an AC20 for harder targets and a fast firing laser for smaller ones."
+	equip_by_category = list(
+		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/ac20,
+		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser,
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/radio, /obj/item/mecha_parts/mecha_equipment/air_tank/full),
+		MECHA_POWER = list(),
+		MECHA_ARMOR = list(),)
+
+
+
+/obj/vehicle/sealed/mecha/marauder/seraph/firewall/populate_parts()
+	cell = new /obj/item/stock_parts/cell/hyper(src)
+	scanmod = new /obj/item/stock_parts/scanning_module/adv(src)
+	capacitor = new /obj/item/stock_parts/capacitor/adv(src)
+	servo = new /obj/item/stock_parts/servo/nano(src)
+	update_part_values()

--- a/modular_np_lethal/mechs_buffs/code/mechs/marauder.dm
+++ b/modular_np_lethal/mechs_buffs/code/mechs/marauder.dm
@@ -37,14 +37,16 @@
 //Seraph, evil marauder. better in every way, it's probably the most dangerous of all the big dumb evil mechs. All evil mechs are for admin events/big boss fights.
 // It's similar to a durand in it's durability but can walk around the speed of a gygax. Be afraid.
 
+//Nvm now it's a filtre mech, fast as a marauder, cant take injurys and has the health of a durand
+
 /obj/vehicle/sealed/mecha/marauder/seraph
 	armor_type = /datum/armor/mecha_seraph
-	movedelay = 3
-	internal_damage_threshold = 25
+	movedelay = 4
+	internal_damage_threshold = 0
 	internal_damage_probability = 10
 	max_integrity = 1000
 	wreckage = /obj/structure/mecha_wreckage/seraph
-	force = 35
+	force = 40
 	max_equip_by_category = list(
 		MECHA_L_ARM = 1,
 		MECHA_R_ARM = 1,


### PR DESCRIPTION
'dente are you crazy'

yeah kinda.

TLDR: nerfs the seraph to be like 30% better then most other mechs we have right now, give it to filtres for the hefty cost of 8 IDS.

OKAY HEAR ME OUT.

Filtres have a very good mid game, but a pretty shit end game. Getting out scaled by multiple exosuits and high armored gaksters. To even the playing field for good ass gamer filtres we bring, the serpah. The Seraph is as tanky as a durand with the speed and utility of a marauder, it's certainly the best useable mech in the game besides maybe the savahnna ivanov, however it costs filtres 8 total ID's. Realistically it's still a mech, firing the same weapons as all the other mechs it could probably be cheaper but I'd rather keep it as a rarity for when gaksters fuck up a whole bunch/give away too many ID's

okay the not stupid game design reason is 'WOULDNT IT BE SICK IF FILTRE MECH HAD A SHOWDOWN WITH A NORMAL MECH?' 
and I went, 'yeah that'd be awesome.'

anyway, u didn't tell me not too so if you think this is anti-fun or if it should be more expensive lmk I'm 500% open to killing this idea / modifying it. 