### PR TITLE
Cap deafness to 10 ticks maximum

### DIFF
--- a/modular_np_lethal/deafness_cap/code/deafness_limit.dm
+++ b/modular_np_lethal/deafness_cap/code/deafness_limit.dm
@@ -1,0 +1,23 @@
+/datum/component/limit_deafness
+	// How many ticks of deafness is our maximum?
+	var/max_deafness_ticks = 10
+
+/datum/component/limit_deafness/Initialize(...)
+	. = ..()
+	if (!ishuman(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	RegisterSignal(parent, COMSIG_LIVING_LIFE, PROC_REF(deaf_check))
+
+/datum/component/limit_deafness/proc/deaf_check(mob/living/whatdidyousay)
+	var/mob/living/carbon/human/speakup = whatdidyousay
+	var/obj/item/organ/internal/ears/target_ears = speakup?.get_organ_slot(ORGAN_SLOT_EARS)
+
+	if (target_ears)
+		if (target_ears.deaf > max_deafness_ticks)
+			target_ears.deaf = min(max_deafness_ticks, target_ears.deaf)
+			to_chat(speakup, span_notice("The ringing in your ears begins to fade..."))
+
+/mob/living/carbon/human/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/limit_deafness)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8399,6 +8399,7 @@
 #include "modular_np_lethal\clothing_edits\gear_harness_change.dm"
 #include "modular_np_lethal\cyborg_hands\code\cyborg_hands.dm"
 #include "modular_np_lethal\cyborg_hands\code\outline_element.dm"
+#include "modular_np_lethal\deafness_cap\code\deafness_limit.dm"
 #include "modular_np_lethal\deepmaint_stuff\code\areas_n_shit.dm"
 #include "modular_np_lethal\deepmaint_stuff\code\entrance_and_exit.dm"
 #include "modular_np_lethal\deepmaint_stuff\code\filtre_job.dm"
@@ -8511,4 +8512,5 @@
 #include "modular_np_lethal\movement\code\living_z_level.dm"
 #include "modular_np_lethal\mutations\code\chameleon.dm"
 #include "modular_np_lethal\mutations\code\cryokinesis.dm"
+
 // END_INCLUDE


### PR DESCRIPTION
Scrungly component that just checks on life ticks if someone is deaf for more than 10 ticks, and if so, caps it to 10 ticks.

Flashbangs typically give 15 ticks of deafness, so this reduces it to 10. It tends to work out to about the time they stay on the floor from the flash stun for, as a frame of reference.