### PR TITLE
Flaming June: Bespoke LETHALSTATION(tm) firestacks mechanics

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -144,8 +144,11 @@
 	if(!on_fire)
 		return TRUE
 
-	var/decay_multiplier = HAS_TRAIT(owner, TRAIT_HUSK) ? 2 : 1 // husks decay twice as fast
-	adjust_stacks(owner.fire_stack_decay_rate * decay_multiplier * seconds_between_ticks)
+	var/decay_multiplier = HAS_TRAIT(owner, TRAIT_HUSK) ? 4 : 1 // LETHAL EDIT: husks burn out four times as fast
+	// LETHAL EDIT START: fire stacks no longer decay above 10 if you're alive and not a husk
+	if (stacks < 10 || HAS_TRAIT(owner, TRAIT_HUSK))
+		adjust_stacks(owner.fire_stack_decay_rate * decay_multiplier * seconds_between_ticks)
+	// LETHAL EDIT END
 
 	if(stacks <= 0)
 		qdel(src)

--- a/modular_np_lethal/firestacks/code/fire_adjustment.dm
+++ b/modular_np_lethal/firestacks/code/fire_adjustment.dm
@@ -1,0 +1,26 @@
+// LETHALSTATION FIRE ADJUSTMENTS
+// Before: -0.05 fire stacks per tick, always
+// After: -0.35 fire stacks per tick (7x increase), but only if below 10 stacks, otherwise no reduction at all.
+// The intent here is to keep incendiaries as a viable weapon type but make being clipped by a single shot or flame grenade not be a world-ending experience.
+
+/mob/living
+	fire_stack_decay_rate = -0.35
+
+/datum/status_effect/fire_handler/proc/stacks_notify(pre)
+	if (pre < 10 && stacks >= 10)
+		owner.visible_message(span_warning("[owner] erupts into a roaring blaze!"), span_boldwarning("The flames surrounding you erupt into a roaring blaze - <i>RESIST</i> to put them out!"))
+		return
+
+	if (pre >= 10 && stacks <= 9)
+		owner.visible_message(span_warning("The flames engulfing [owner] begin to sputter and die out of their own accord."), span_warning("The flames engulfing you begin to die down on their own..."))
+		return
+
+/datum/status_effect/fire_handler/set_stacks(new_stacks)
+	var/pre = stacks
+	. = ..()
+	stacks_notify(pre)
+
+/datum/status_effect/fire_handler/adjust_stacks(new_stacks)
+	var/pre = stacks
+	. = ..()
+	stacks_notify(pre)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8444,6 +8444,7 @@
 #include "modular_np_lethal\epic_loot\code\loot_structures\toolbox.dm"
 #include "modular_np_lethal\epic_loot\code\loot_structures\wall_jackets.dm"
 #include "modular_np_lethal\epic_loot\code\storage_containers\containers.dm"
+#include "modular_np_lethal\firestacks\code\fire_adjustment.dm"
 #include "modular_np_lethal\genemod_quirk\code\genemod_quirk.dm"
 #include "modular_np_lethal\I_HATE_SYNTH_WOUNDS!!\code\pierce.dm"
 #include "modular_np_lethal\I_HATE_SYNTH_WOUNDS!!\code\robotic_blunt.dm"


### PR DESCRIPTION
## About The Pull Request

Incendiaries are oppressively strong. Everybody knows this. The thing that makes them especially bad is that the base fire stacks clear *really* slowly. Here's the changes I've made:

- The base rate at which a human mob clears fire stacks has been increased from *0.05* to **0.35** per tick.
- If someone has over **10** fire stacks, they no longer clear fire stacks naturally and **MUST** extinguish themselves via RESISTing or an outside source (extinguisher).
  - Previously, fire stacks continued to clear themselves and decay forever, just at a really slow rate.
- A husked corpse now clears its fire stacks 4x faster instead of 2x faster. You've already been burnt out, yo.

These changes include in-game messaging that very clearly tells you when you're in a position that your fire will no longer clear itself out (>10 stacks), and when you drop below that threshold (<10 stacks). 

Note: this does make resisting down out of 10+ stacks of fire *slightly* longer than before, because previously, you were benefitting from the always-on-but-almost-uselessly-feeble fire stack decay rate. Once you drop below 10 stacks, you'll put yourself out really quickly when resisting, and decently fast when just running around.

The intent behind these is to keep incendiary weapons as an interesting niche and mechanic, but make them less "welp i've been set on fire once i have to stunlock myself or die to fire wounds". Some really strong one-off incendiary effects will give more than 10 stacks and those should be coveted because of this.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: yooriss
balance: Fire stacks now decay 7x faster than before at a basic level, but no longer decay at all above 10 stacks. In-game chat messages will tell you when you exceed 10 stacks.
/:cl:
