### PR TITLE
Difficulty Increase: Experimental LETHALSTATION mob AI adjustments

### DIFF
--- a/code/datums/components/ranged_attacks.dm
+++ b/code/datums/components/ranged_attacks.dm
@@ -84,7 +84,7 @@
 		target_zone = ran_zone()
 	casing.fire_casing(target, firer, null, null, null, target_zone, 0,  firer)
 	casing.update_appearance()
-	casing.AddElement(/datum/element/temporary_atom, 30 SECONDS)
+	// casing.AddElement(/datum/element/temporary_atom, 30 SECONDS) - this causes runtimes out the ass for some reason
 	SEND_SIGNAL(parent, COMSIG_BASICMOB_POST_ATTACK_RANGED, target, modifiers)
 	return
 

--- a/modular_np_lethal/mobs/lethalmobs.dm
+++ b/modular_np_lethal/mobs/lethalmobs.dm
@@ -7,6 +7,8 @@
 	ai_controller = /datum/ai_controller/basic_controller/trooper/gakster
 	loot = list(/obj/effect/mob_spawn/corpse/human/gakstermob)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/gakstermob
+	move_resist = MOVE_FORCE_NORMAL
+	speed = 0.8
 
 /mob/living/basic/trooper/gakster/Initialize(mapload)
 	. = ..()
@@ -26,6 +28,8 @@
 		"Hostile spotted!",
 		"Enemy spotted!",
 	), speech_chance = 95, subtract_chance = 5, minimum_chance = 15)
+	AddElement(/datum/element/ai_retaliate)
+	AddElement(/datum/element/ai_flee_while_injured)
 
 /mob/living/basic/trooper/gakster/melee_attack(mob/living/target, list/modifiers, ignore_cooldown)
 	. = ..()
@@ -53,7 +57,7 @@
 		"Stop moving, dammit!",
 		"Fuck you!",
 	)
-	if(prob(25))
+	if(prob(5))
 		say(language = /datum/language/gutter, message = pick(melee_taunts))
 
 /mob/living/basic/trooper/gakster/apply_damage(damage, damagetype, def_zone, blocked, forced, spread_damage, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item)
@@ -80,7 +84,7 @@
 		"Stop resisting!",
 		"Fuck you!",
 	)
-	if(prob(40))
+	if(prob(15))
 		say(language = /datum/language/gutter, message = pick(pain_taunts))
 
 /mob/living/basic/trooper/gakster/melee
@@ -93,6 +97,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
 	r_hand = /obj/item/knife/combat
+	speed = 0.5
 
 /mob/living/basic/trooper/gakster/ranged
 	desc = "A gakster armed with a Seiba .27-54 submachinegun. They look pretty angry."
@@ -103,6 +108,7 @@
 	var/projectilesound = 'modular_np_lethal/lethalguns/sound/seiba/seiba.wav'
 	var/burst_shots = 3
 	var/ranged_cooldown = 0.4 SECONDS
+	speed = 0.9
 
 /mob/living/basic/trooper/gakster/ranged/Initialize(mapload)
 	. = ..()
@@ -113,6 +119,7 @@
 		cooldown_time = ranged_cooldown,\
 		burst_shots = burst_shots,\
 	)
+	AddElement(/datum/element/ai_flee_while_injured)
 	if (ranged_cooldown <= 1 SECONDS)
 		AddComponent(/datum/component/ranged_mob_full_auto)
 
@@ -139,7 +146,7 @@
 		"Fucker!",
 		"Bastard!",
 	)
-	if(prob(25))
+	if(prob(5))
 		say(language = /datum/language/gutter, message = pick(ranged_taunts))
 
 /mob/living/basic/trooper/gakster/suicide
@@ -186,6 +193,7 @@
 	faction = list(ROLE_DEATHSQUAD)
 	loot = list(/obj/effect/mob_spawn/corpse/human/filtremob)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/filtremob
+	speed = 1.2
 
 /mob/living/basic/trooper/gakster/melee/filtre
 	name = "Blue Company Filtre"
@@ -205,6 +213,7 @@
 	projectilesound = 'modular_np_lethal/lethalguns/sound/yari/yari.wav'
 	burst_shots = 1
 	ranged_cooldown = 0.5 SECONDS
+	speed = 1.2
 
 /// BOSS MOBS
 
@@ -222,6 +231,7 @@
 	projectilesound = 'modular_nova/modules/modular_weapons/sounds/grenade_launcher.ogg'
 	burst_shots = 1
 	ranged_cooldown = 2.5 SECONDS
+	speed = 1
 
 // 201 Fathomer : Drops Ramu 6 gauge shotgun, a bunch of 6g longshot ammo, and sacrificial armor
 /mob/living/basic/trooper/gakster/ranged/fathomer
@@ -236,6 +246,7 @@
 	projectilesound = 'modular_np_lethal/lethalguns/sound/ramu/ramu.wav'
 	burst_shots = 1
 	ranged_cooldown = 1.3 SECONDS
+	speed = 0.6
 
 // 253 Chauchat : Drops a Seiba & ballistic shield alongside ammunition and a full set of type 3 armor + helmet
 /mob/living/basic/trooper/gakster/ranged/chauchat
@@ -251,6 +262,7 @@
 	projectilesound = 'modular_np_lethal/lethalguns/sound/seiba/seiba.wav'
 	burst_shots = 3
 	ranged_cooldown = 0.4 SECONDS
+	speed = 1.2
 
 // 287 Prophet : Drops double energy sword and type five armor
 /mob/living/basic/trooper/gakster/melee/prophet
@@ -270,3 +282,4 @@
 	light_range = 6
 	light_power = 2.5
 	light_color = COLOR_SOFT_RED
+	speed = 0.3

--- a/modular_np_lethal/mobs/mob_ai.dm
+++ b/modular_np_lethal/mobs/mob_ai.dm
@@ -57,22 +57,77 @@
 /datum/ai_controller/basic_controller/trooper/gakster
 	blackboard = list(
 		BB_TARGETING_STRATEGY = /datum/targeting_strategy/basic,
-		BB_AGGRO_RANGE = 16,
+		BB_AGGRO_RANGE = 9,
+		BB_VISION_RANGE = 9,
 		BB_EMOTE_KEY = "swear",
+		BB_CURRENT_HUNTING_TARGET = null,
+		BB_TARGET_MINIMUM_STAT = HARD_CRIT,
+		BB_BASIC_MOB_FLEE_DISTANCE = 12,
+		BB_REINFORCEMENTS_EMOTE = "reaches up to their comtac and utters a code phrase.",
 	)
+
+	ai_movement = /datum/ai_movement/jps
+	idle_behavior = /datum/idle_behavior/walk_near_target
+	interesting_dist = 20
+	can_idle = FALSE // want them to remain responsive
+
 	planning_subtrees = list(
+		/datum/ai_planning_subtree/flee_target/from_flee_key,
+		/datum/ai_planning_subtree/find_and_hunt_target/gakster,
 		/datum/ai_planning_subtree/simple_find_target,
 		/datum/ai_planning_subtree/attack_obstacle_in_path/trooper,
 		/datum/ai_planning_subtree/basic_melee_attack_subtree,
-		/datum/ai_planning_subtree/travel_to_point/and_clear_target/reinforce,
 		/datum/ai_planning_subtree/run_emote,
 	)
 
 /datum/ai_controller/basic_controller/trooper/gakster/ranged
 	planning_subtrees = list(
+		/datum/ai_planning_subtree/flee_target/from_flee_key,
+		/datum/ai_planning_subtree/find_and_hunt_target/gakster,
 		/datum/ai_planning_subtree/simple_find_target,
-		/datum/ai_planning_subtree/basic_ranged_attack_subtree/trooper,
-		/datum/ai_planning_subtree/travel_to_point/and_clear_target/reinforce,
+		//datum/ai_planning_subtree/ranged_skirmish/gakster,
+		/datum/ai_planning_subtree/basic_ranged_attack_subtree/gakster,
+		/datum/ai_planning_subtree/maintain_distance/cover_minimum_distance/gakster_ranged,
 		/datum/ai_planning_subtree/run_emote,
-		/datum/ai_planning_subtree/ranged_skirmish,
 	)
+
+/datum/ai_planning_subtree/basic_ranged_attack_subtree/gakster
+	ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack/gakster
+
+/datum/ai_behavior/basic_ranged_attack/gakster
+	action_cooldown = 1 SECONDS
+	required_distance = 7
+	avoid_friendly_fire = TRUE
+
+/datum/ai_planning_subtree/ranged_skirmish/gakster
+	min_range = 0
+
+/datum/ai_planning_subtree/maintain_distance/cover_minimum_distance/gakster_ranged
+	minimum_distance = 1
+	maximum_distance = 7
+	view_distance = 7
+
+/datum/ai_behavior/hunt_target/gakster
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	always_reset_target = TRUE
+
+/datum/ai_behavior/hunt_target/gakster/target_caught(mob/living/hunter, atom/hunted)
+	return
+
+/datum/ai_planning_subtree/find_and_hunt_target/gakster
+	finish_planning = FALSE
+	hunt_targets = list(/mob/living/carbon/human)
+	finding_behavior = /datum/ai_behavior/find_hunt_target/gakster_through_walls
+	hunting_behavior = /datum/ai_behavior/hunt_target/gakster
+	hunt_range = 9
+
+/datum/ai_behavior/find_hunt_target/gakster_through_walls
+
+/datum/ai_behavior/find_hunt_target/gakster_through_walls/valid_dinner(mob/living/source, atom/dinner, radius, datum/ai_controller/controller, seconds_per_tick)
+	// totally ignores walls. TERROR INCARNATE. you WILL JUMP SCARE PEOPLE.
+	if (isliving(dinner))
+		var/mob/living/living_target = dinner
+		if (living_target.stat == DEAD)
+			return FALSE
+
+	return get_dist(source, dinner) <= radius


### PR DESCRIPTION
I have performed profanity.

These changes are too funny and terrifying not to try live for a little bit. You will shit your pants.

Summary:
- Gakster mobs now move significantly faster and in the case of some boss mobs, can outrun you. They also never slow down no matter how much damage they take.
- Gakster mobs use `jps` pathfinding and resist many common SS13 cheese tactics. You can still cheese them - I'm not going to claim you can't, but it's a bit harder now.
- **Gakster mobs will now hear you passing by (they can essentially SEE THROUGH WALLS) and will investigate the source of this noise: YOU.**
   - This single change turns Sector 9 into a horror game. Running from one gakster may have you pull camps of several more.
- Gakster mobs will relentlessly hunt any human creature they can detect.
- Ranged gakster mobs will try to keep you at a respectable distance more frequently.
- Melee gakster mobs will rush you down hallways.
- Gakster mobs will sometimes attempt to flee when they get close to death.
- Gaksters will try to avoid friendly-firing one another.
- Gaksters will attempt to retaliate in some circumstances if attacked by things they're not friendly with. You can use the thing in bay 14 to your advantage if you're feeling frisky.
- As above, this means that Filtre and Gakster NPCs may spontaneously engage in warfare if tracked into one another.
- You can no longer effortlessly phase through Gakster NPCs to escape them. If you get cornered in a hallway, fight or die.