### PR TITLE
pinata edits

### DIFF
--- a/modular_np_lethal/deepmaint_stuff/code/pinata_job.dm
+++ b/modular_np_lethal/deepmaint_stuff/code/pinata_job.dm
@@ -85,16 +85,6 @@
 
 	squaddie.mind?.adjust_experience(/datum/skill/athletics, 10000000)
 
-	var/list/bodyparts_to_replace = list(
-		/obj/item/bodypart/leg/left/robot/advanced,
-		/obj/item/bodypart/leg/right/robot/advanced,
-		/obj/item/bodypart/arm/left/robot/advanced,
-		/obj/item/bodypart/arm/right/robot/advanced,
-	)
-	for(var/iterated_bodypart in bodyparts_to_replace)
-		var/obj/item/bodypart/new_bodypart = new iterated_bodypart()
-		new_bodypart.replace_limb_evil(squaddie, special = TRUE)
-
 	var/list/implants_to_add = list(
 		/obj/item/organ/internal/ears/cybernetic/whisper,
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,

--- a/modular_np_lethal/deepmaint_stuff/code/resupply_doohickey_pinata.dm
+++ b/modular_np_lethal/deepmaint_stuff/code/resupply_doohickey_pinata.dm
@@ -134,4 +134,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/vending/wallmed/epic_loot/evil/inborn
 				/obj/item/organ/internal/cyberimp/arm/armblade = INFINITY,
 			),
 		),
+		list(
+			"name" = "Limb Replacement",
+			"icon" = "hand",
+			"products" = list(
+				/obj/item/bodypart/leg/left/robot/advanced = INFINITY,
+				/obj/item/bodypart/leg/right/robot/advanced = INFINITY,
+				/obj/item/bodypart/arm/left/robot/advanced = INFINITY,
+				/obj/item/bodypart/arm/right/robot/advanced = INFINITY,
+				/obj/item/shears  = INFINITY,
+			),
+		),
+
 	)


### PR DESCRIPTION
adds advanced limbs to the super evil clothesmate for pinatas, and an amp shear. diables advanced limbs being spawned with the user

this allows for the player's custom markings and arms to remain by default, while still giving them the option 2 get better limbs at the cost of drip