### PR TITLE
gakster ai edits - organ fix (temp) ?? just trying to get a feel for this

### DIFF
--- a/modular_np_lethal/mobs/lethalmobs.dm
+++ b/modular_np_lethal/mobs/lethalmobs.dm
@@ -1,17 +1,13 @@
-/obj/effect/mob_spawn/corpse/human/special(mob/living/carbon/human/spawned_human)
-	. = ..()
-	QDEL_LIST(spawned_human.organs) // no organs in our corpses since they're currency
-
 /mob/living/basic/trooper/gakster
 	name = "Gakster"
 	desc = "This assclown looks like they barely know what they're doing."
-	maxHealth = 100
-	health = 100
+	maxHealth = 110
+	health = 110
 	faction = list(ROLE_SYNDICATE)
 	ai_controller = /datum/ai_controller/basic_controller/trooper/gakster
 	loot = list(/obj/effect/mob_spawn/corpse/human/gakstermob)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/gakstermob
-	move_resist = MOVE_FORCE_STRONG
+	move_resist = MOVE_FORCE_NORMAL
 	speed = 0.8
 	// What range do we want this NPC to operate at?
 	var/effective_range = 1
@@ -137,7 +133,7 @@
 	var/casingtype = /obj/item/ammo_casing/c27_54cesarzowa
 	var/projectilesound = 'modular_np_lethal/lethalguns/sound/seiba/seiba.wav'
 	var/burst_shots = 2
-	var/ranged_cooldown = 0.6 SECONDS
+	var/ranged_cooldown = 0.8 SECONDS
 	speed = 0.9
 	effective_range = 4
 

--- a/modular_np_lethal/mobs/lethalmobs.dm
+++ b/modular_np_lethal/mobs/lethalmobs.dm
@@ -1,3 +1,8 @@
+/obj/effect/mob_spawn/corpse/human/special(mob/living/carbon/human/spawned_human)
+	. = ..()
+	for (var/obj/item/organ/internal/part in spawned_human.organs)
+		part.organ_flags |= ORGAN_UNREMOVABLE
+
 /mob/living/basic/trooper/gakster
 	name = "Gakster"
 	desc = "This assclown looks like they barely know what they're doing."


### PR DESCRIPTION

## About The Pull Request

reverts a change to the move resistance of gaksters (swarm tactics and strong move resist showed a lot of ppl getting cornered / locked into one tile and dying) - Not Fun

reverts the organ removal update so that gakster npcs can have eyes and brains again (stop larping as zombies, it's june!) can be re-added or otherwise modified in the future to where organs get deleted on-death, maybe?

adjusted gakster weapon cooldown from 0.6 to 0.8 seconds- the timer counts them from the moment of attack, not attack-end, so they were firing wayy quicker than 0.6

ups gakster npc health by 10 to account for the slight nerf of the lack of movement resistance n weapon delay? could go up more, this is largely a temp fix and small balance attempt to see how it feels

## How This Contributes To The Nova Sector Roleplay Experience

whats a nova sector

## Proof of Testing

code

