### PR TITLE
gureibu fix + armor trade description fix + adding water tanks to places for extinguisher refilling

### DIFF
--- a/_maps/map_files/lethal/comvat.dmm
+++ b/_maps/map_files/lethal/comvat.dmm
@@ -173,6 +173,10 @@
 /obj/machinery/light/small/red/dim/directional/west,
 /turf/open/floor/catwalk_floor/titanium,
 /area/gakster_location/hideout_real)
+"ba" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "bb" = (
 /obj/structure/fluff/metalpole{
 	dir = 4
@@ -8875,6 +8879,11 @@
 /obj/machinery/light/cold/dim/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/gakster_location/war)
+"WV" = (
+/obj/machinery/vending/wallmed/epic_loot/directional/south,
+/obj/structure/reagent_dispensers/water_cooler/directional/east,
+/turf/open/indestructible/stone,
+/area/gakster_location/hideout_real)
 "WW" = (
 /obj/machinery/barsign/all_access,
 /turf/closed/indestructible/wood,
@@ -35296,7 +35305,7 @@ NT
 jI
 dK
 NT
-Lh
+ba
 Lh
 lv
 NT
@@ -52687,7 +52696,7 @@ ca
 lj
 yY
 lj
-oA
+WV
 KC
 yY
 Kk

--- a/_maps/map_files/lethal/comvat.dmm
+++ b/_maps/map_files/lethal/comvat.dmm
@@ -7387,6 +7387,10 @@
 /obj/machinery/light/cold/dim/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/gakster_location/war)
+"OE" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/closed/indestructible/titanium/nodiagonal,
+/area/gakster_location/filtre_spawn)
 "OF" = (
 /obj/structure/table,
 /obj/machinery/light/dim/directional/west,
@@ -53556,7 +53560,7 @@ Vi
 vn
 vn
 vn
-vn
+OE
 wg
 wg
 vn

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/ammo/grenade.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/ammo/grenade.dm
@@ -38,7 +38,10 @@
 		loaded_projectile.range = firing_launcher.target_range
 	else if(istype(fired_from, /obj/item/gun/ballistic/shotgun/shell_launcher))
 		loaded_projectile.range = 5
-
+	// LETHAL EDIT: gureibu's GL sets range
+	else if(istype(fired_from, /obj/item/gun/ballistic/revolver/grenadelauncher/tydhouer))
+		loaded_projectile.range = get_dist(user, target)
+	// LETHAL EDIT END
 	. = ..()
 
 

--- a/modular_np_lethal/deepmaint_stuff/code/order_console_slop/order_console.dm
+++ b/modular_np_lethal/deepmaint_stuff/code/order_console_slop/order_console.dm
@@ -63,7 +63,7 @@
 		/obj/item/epic_loot/corpo_folder = PAYCHECK_COMMAND * 2,
 		/obj/item/epic_loot/intel_folder = PAYCHECK_COMMAND * 2,
 		/obj/item/epic_loot/gold_chainlet = PAYCHECK_COMMAND * 2,
-		/obj/item/gun = PAYCHECK_COMMAND
+		/obj/item/gun = PAYCHECK_COMMAND,
 	)
 
 /obj/machinery/computer/order_console/gakster/examine(mob/user)

--- a/modular_np_lethal/deepmaint_stuff/code/trade_station_types/armor.dm
+++ b/modular_np_lethal/deepmaint_stuff/code/trade_station_types/armor.dm
@@ -39,8 +39,8 @@
 	. += span_notice("<b>1</b> electric motor = <b>1</b> type II 'Kastrol' helmet")
 	. += span_notice("<b>1</b> shuttle gyroscope = <b>1</b> type II 'Muur' vest")
 	. += span_notice("<b>1</b> shuttle battery = <b>1</b> type II 'Muur' helmet")
-	. += span_notice("<b>2</b> hearts = <b>1</b> CIN surplus vest")
-	. += span_notice("<b>2</b> stomachs = <b>1</b> CIN surplus helmet")
+	. += span_notice("<b>1</b> graphics processor = <b>1</b> CIN surplus vest")
+	. += span_notice("<b>1</b> broken display = <b>1</b> CIN surplus helmet")
 	. += span_notice("<b>1</b> fuel conditioner = <b>1</b> frontier headset")
 	. += span_notice("<b>1</b> phased array element = <b>1</b> bowman headset")
 	return .

--- a/modular_np_lethal/epic_loot/code/_basetype.dm
+++ b/modular_np_lethal/epic_loot/code/_basetype.dm
@@ -6,7 +6,7 @@
 	layer = BELOW_OBJ_LAYER
 	obj_flags = CAN_BE_HIT
 	pass_flags_self = LETPASSTHROW|LETPASSCLICKS
-	max_integrity = 100
+	max_integrity = 200
 
 	/// What storage datum we use
 	var/storage_datum_to_use = /datum/storage/maintenance_loot_structure

--- a/modular_np_lethal/lethalguns/code/suppressed.dm
+++ b/modular_np_lethal/lethalguns/code/suppressed.dm
@@ -90,6 +90,11 @@
 	/// The stored under-barrel grenade launcher for this weapon
 	var/obj/item/gun/ballistic/revolver/grenadelauncher/tydhouer/underbarrel
 
+/obj/item/gun/ballistic/automatic/suppressed_rifle/grenade_launcher/try_fire_gun(atom/target, mob/living/user, params)
+	if(LAZYACCESS(params2list(params), RIGHT_CLICK))
+		return underbarrel.try_fire_gun(target, user, params)
+	return ..()
+
 /obj/item/gun/ballistic/automatic/suppressed_rifle/grenade_launcher/Initialize(mapload)
 	. = ..()
 	underbarrel = new /obj/item/gun/ballistic/revolver/grenadelauncher/tydhouer(src)


### PR DESCRIPTION
## About The Pull Request

adds a water tank to the. dorms area in the warehouse? with the laundry cart.
adds a water cooler to the gakster base for epic water drinking roleplay (and/or refilling extinguishers)

---

makes the gureibo able to fire its underbarrel grenade launcher. the gureibo's grenades set range depending on where you fire

---

fixes some incorrect armor trade descriptors
## Changelog


:cl:
fix: The Gureibo-GL's grenade launcher is now actually capable of firing. Grenades fired out of it airburst where the operator aims.
fix: The descriptors for the CIN surplus armor trade from the armor supplier has been fixed.
add: For the sake of extinguisher refilling, a water tank has been added to the warehouse dorms area storage closet, a high-capacity water tank is present in the Filtre ship, and a water cooler is now present in the pentola.
/:cl:
