### PR TITLE
makes da changeling bossroom so epic....

### DIFF
--- a/_maps/map_files/lethal/comvat.dmm
+++ b/_maps/map_files/lethal/comvat.dmm
@@ -3290,6 +3290,11 @@
 /obj/effect/turf_decal/arrows/red,
 /turf/open/indestructible/stone,
 /area/gakster_location/hideout_real)
+"rC" = (
+/obj/structure/ladder,
+/obj/structure/lattice/catwalk,
+/turf/open/chasm,
+/area/gakster_location/outside)
 "rD" = (
 /obj/effect/spawner/random/trash,
 /turf/open/indestructible/plating,
@@ -3880,6 +3885,10 @@
 /obj/machinery/processor,
 /turf/open/indestructible/kitchen,
 /area/gakster_location/hideout_real)
+"uZ" = (
+/obj/structure/lattice/catwalk,
+/turf/open/chasm,
+/area/gakster_location/outside)
 "va" = (
 /obj/structure/table,
 /obj/effect/spawner/random/epic_loot/random_provisions,
@@ -5326,6 +5335,10 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/gakster_location/war)
+"CK" = (
+/obj/structure/lattice,
+/turf/open/chasm,
+/area/gakster_location/outside)
 "CL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -7288,6 +7301,12 @@
 	},
 /turf/open/indestructible/dark/smooth_large,
 /area/gakster_location/hideout_real)
+"Nb" = (
+/obj/structure/lattice/catwalk{
+	pixel_y = -3
+	},
+/turf/open/openspace,
+/area/gakster_location/outside)
 "Ne" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8803,6 +8822,12 @@
 	},
 /turf/open/indestructible/plating,
 /area/gakster_location/hideout_real)
+"Ve" = (
+/obj/structure/lattice/catwalk{
+	pixel_y = -3
+	},
+/turf/open/chasm,
+/area/gakster_location/outside)
 "Vf" = (
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/freezer,
@@ -13987,7 +14012,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -14089,7 +14114,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -14191,7 +14216,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -14293,7 +14318,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -14395,7 +14420,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -14497,7 +14522,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -14970,11 +14995,11 @@ bU
 bU
 bU
 bU
-bU
-bU
-bU
-bU
-bU
+CK
+CK
+CK
+uZ
+CK
 bU
 bU
 bU
@@ -16977,7 +17002,7 @@ bU
 bU
 bU
 bU
-bU
+CK
 bU
 bU
 bU
@@ -17079,8 +17104,8 @@ bU
 bU
 bU
 bU
-bU
-bU
+CK
+CK
 bU
 bU
 bU
@@ -17181,11 +17206,11 @@ bU
 bU
 bU
 bU
-bU
-bU
-bU
-bU
-bU
+rC
+CK
+CK
+CK
+CK
 bU
 bU
 bU
@@ -17283,7 +17308,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -17385,7 +17410,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -17487,7 +17512,7 @@ bU
 bU
 bU
 bU
-bU
+uZ
 bU
 bU
 bU
@@ -18662,7 +18687,7 @@ bU
 bU
 bU
 bU
-bU
+Ve
 bU
 bU
 bU
@@ -18763,8 +18788,8 @@ bU
 bU
 bU
 bU
-bU
-bU
+CK
+Ve
 bU
 bU
 bU
@@ -18860,13 +18885,13 @@ bU
 bU
 bU
 bU
-bU
-bU
-bU
-bU
-bU
-bU
-bU
+CK
+CK
+CK
+CK
+CK
+CK
+Ve
 bU
 bU
 bU
@@ -18968,10 +18993,10 @@ bU
 bU
 bU
 bU
-bU
-bU
-bU
-bU
+Ve
+CK
+CK
+CK
 bU
 bU
 bU
@@ -19070,7 +19095,7 @@ bU
 bU
 bU
 bU
-bU
+Ve
 bU
 bU
 bU
@@ -19172,7 +19197,7 @@ bU
 bU
 bU
 bU
-bU
+Ve
 bU
 bU
 bU
@@ -27280,7 +27305,7 @@ xw
 xw
 xw
 xw
-Fp
+Nb
 xw
 xw
 xw

--- a/_maps/map_files/lethal/comvat.dmm
+++ b/_maps/map_files/lethal/comvat.dmm
@@ -1735,10 +1735,7 @@
 /turf/open/indestructible/dark/smooth_large,
 /area/gakster_location/hideout_real)
 "jf" = (
-/mob/living/simple_animal/hostile/true_changeling{
-	name = "???"
-	},
-/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/trog,
 /turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "jg" = (
@@ -2640,6 +2637,7 @@
 /area/gakster_location/hideout_real)
 "nQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/trog,
 /turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "nS" = (
@@ -3203,9 +3201,7 @@
 /turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "re" = (
-/mob/living/simple_animal/hostile/true_changeling{
-	name = "???"
-	},
+/mob/living/basic/migo,
 /turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "rf" = (
@@ -5522,6 +5518,10 @@
 	},
 /turf/open/indestructible/plating,
 /area/gakster_location/hideout_real)
+"DB" = (
+/mob/living/simple_animal/hostile/vatbeast,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "DC" = (
 /obj/item/chair/stool/bar,
 /turf/open/floor/wood,
@@ -5718,6 +5718,11 @@
 "EL" = (
 /obj/structure/fluff/tram_rail/electric,
 /turf/open/floor/plating,
+/area/gakster_location/war)
+"EM" = (
+/obj/structure/lattice,
+/mob/living/basic/migo,
+/turf/open/openspace,
 /area/gakster_location/war)
 "EO" = (
 /obj/machinery/light/cold/dim/directional/north,
@@ -6263,6 +6268,11 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/indestructible/hoteltile,
 /area/gakster_location/hideout_real)
+"HP" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/mob/living/simple_animal/hostile/trog,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "HQ" = (
 /obj/structure/rack/shelf,
 /obj/effect/spawner/random/epic_loot/random_tools,
@@ -7468,10 +7478,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/gakster_location/war)
 "NZ" = (
-/mob/living/simple_animal/hostile/true_changeling{
-	name = "???";
-	health = 750
-	},
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/iron/smooth,
 /area/gakster_location/war)
@@ -7532,6 +7538,10 @@
 	},
 /turf/open/indestructible/kitchen,
 /area/gakster_location/hideout_real)
+"Oo" = (
+/mob/living/simple_animal/hostile/ooze/gelatinous,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "Op" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -37289,7 +37299,7 @@ zW
 zW
 Bo
 Bo
-Bo
+jf
 Rr
 Bo
 Bo
@@ -37385,9 +37395,9 @@ no
 iU
 Bo
 Bo
-zW
-re
+EM
 Bo
+jf
 Bo
 JY
 qW
@@ -37587,10 +37597,10 @@ sI
 sI
 no
 zZ
-Bo
+DB
 Bo
 Ok
-ng
+HP
 ng
 tl
 Bo
@@ -37598,7 +37608,7 @@ Bo
 nQ
 Bo
 Bo
-re
+Bo
 Fu
 zW
 PD
@@ -37792,7 +37802,7 @@ sI
 no
 gR
 Bo
-Bo
+Oo
 no
 no
 no
@@ -37893,7 +37903,7 @@ sI
 sI
 no
 gR
-jf
+Ok
 Bo
 no
 Bo

--- a/_maps/map_files/lethal/comvat.dmm
+++ b/_maps/map_files/lethal/comvat.dmm
@@ -230,8 +230,9 @@
 /turf/open/floor/mineral/titanium/white,
 /area/gakster_location/hideout_real)
 "bj" = (
-/obj/machinery/computer/terminal,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/mob_spawn/corpse/human/filtremob,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "bl" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -419,6 +420,10 @@
 /obj/structure/maintenance_loot_structure/wall_jacket/random/directional/north,
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
+/area/gakster_location/war)
+"cx" = (
+/obj/effect/spawner/random/epic_loot/pocket_sized_valuables,
+/turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "cy" = (
 /obj/structure/table/glass,
@@ -804,12 +809,9 @@
 /turf/open/floor/iron/grimy,
 /area/gakster_location/hideout_real)
 "eI" = (
-/mob/living/simple_animal/hostile/true_changeling{
-	name = "???";
-	health = 750
-	},
-/turf/open/floor/iron/smooth,
-/area/gakster_location/war)
+/obj/effect/spawner/random/trash/graffiti,
+/turf/closed/indestructible/opshuttle,
+/area/gakster_location/ninja_hideout)
 "eJ" = (
 /obj/machinery/vending/wallmed/epic_loot/directional/north,
 /turf/open/floor/iron/smooth_large,
@@ -1348,7 +1350,7 @@
 /obj/structure/deepmaints_entrance/ninja,
 /obj/structure/deepmaints_entrance/ninja,
 /obj/machinery/light/cold/dim/directional/west,
-/turf/open/floor/bamboo/tatami/black,
+/turf/open/indestructible/plating,
 /area/gakster_location/ninja_hideout)
 "hf" = (
 /obj/structure/table,
@@ -1732,6 +1734,13 @@
 	},
 /turf/open/indestructible/dark/smooth_large,
 /area/gakster_location/hideout_real)
+"jf" = (
+/mob/living/simple_animal/hostile/true_changeling{
+	name = "???"
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "jg" = (
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/smooth,
@@ -1984,6 +1993,10 @@
 /obj/structure/rack/shelf,
 /turf/open/floor/iron/smooth_large,
 /area/gakster_location/hideout_real)
+"kx" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "ky" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/dark/textured,
@@ -2325,6 +2338,11 @@
 /obj/structure/maintenance_loot_structure/military_case/random,
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
+/area/gakster_location/war)
+"mn" = (
+/obj/effect/mob_spawn/corpse/human/filtremob,
+/obj/effect/spawner/random/epic_loot/pocket_sized_valuables,
+/turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "mo" = (
 /obj/machinery/door/airlock/grunge,
@@ -2945,6 +2963,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/grimy,
 /area/gakster_location/hideout_real)
+"pI" = (
+/obj/effect/spawner/random/lethalstation_armor_set/filtre_light,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "pJ" = (
 /obj/machinery/vending/wallmed/epic_loot/directional/north,
 /turf/open/floor/mineral/titanium/white,
@@ -3085,7 +3107,7 @@
 /area/gakster_location/hideout_real)
 "qB" = (
 /obj/machinery/iv_drip/health_station/directional/north,
-/turf/open/floor/bamboo/tatami/black,
+/turf/open/indestructible/plating,
 /area/gakster_location/ninja_hideout)
 "qD" = (
 /obj/structure/rack/shelf,
@@ -3166,7 +3188,6 @@
 /area/gakster_location/hideout_real)
 "qW" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/spawner/random/lethalstation_armor_set/filtre_light,
 /turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "qZ" = (
@@ -3182,9 +3203,10 @@
 /turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "re" = (
-/obj/structure/showcase/horrific_experiment,
-/obj/machinery/light/broken/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
+/mob/living/simple_animal/hostile/true_changeling{
+	name = "???"
+	},
+/turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "rf" = (
 /obj/machinery/vending/wallmed/epic_loot/directional/north,
@@ -3577,9 +3599,9 @@
 /turf/open/indestructible/plating,
 /area/gakster_location/hideout_real)
 "tl" = (
-/obj/machinery/light/broken/directional/north,
-/obj/structure/maintenance_loot_structure/military_case/random/rare_loot,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/mob_spawn/corpse/human/filtremob,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "tn" = (
 /obj/effect/spawner/random/entertainment/arcade,
@@ -4078,7 +4100,7 @@
 /area/gakster_location/war)
 "wl" = (
 /obj/machinery/iv_drip/health_station/directional/south,
-/turf/open/floor/bamboo/tatami/black,
+/turf/open/indestructible/plating,
 /area/gakster_location/ninja_hideout)
 "wm" = (
 /obj/structure/table/optable,
@@ -4363,6 +4385,11 @@
 /obj/effect/spawner/random/epic_loot/random_ammunition,
 /turf/open/floor/iron/dark/smooth_large,
 /area/gakster_location/war)
+"xS" = (
+/obj/structure/table,
+/obj/machinery/microwave/frontier_printed,
+/turf/open/indestructible/plating,
+/area/gakster_location/ninja_hideout)
 "xU" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/light/small/dim/directional/west,
@@ -4706,9 +4733,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/gakster_location/war)
 "zA" = (
-/obj/structure/closet/wardrobe,
 /obj/item/storage/medkit/frontier/stocked,
 /obj/item/storage/medkit/robotic_repair/stocked,
+/obj/structure/closet,
 /turf/open/floor/bamboo/tatami/black,
 /area/gakster_location/ninja_hideout)
 "zB" = (
@@ -5926,6 +5953,10 @@
 /obj/structure/maintenance_loot_structure/medbox/random,
 /turf/open/floor/iron/dark/smooth_large,
 /area/gakster_location/war)
+"Gh" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "Gk" = (
 /obj/machinery/shower/directional/west,
 /obj/structure/drain,
@@ -6055,6 +6086,11 @@
 /obj/structure/displaycase/captain,
 /obj/machinery/light/warm/dim/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
+/area/gakster_location/war)
+"GR" = (
+/obj/machinery/light/broken/directional/south,
+/obj/structure/lattice,
+/turf/open/openspace,
 /area/gakster_location/war)
 "GV" = (
 /obj/machinery/light/red/dim/directional/north,
@@ -6960,6 +6996,10 @@
 /obj/machinery/light/cold/dim/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/gakster_location/war)
+"LD" = (
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/iron/smooth,
+/area/gakster_location/war)
 "LG" = (
 /obj/structure/sign/poster/contraband/blasto_detergent,
 /turf/closed/indestructible/steel,
@@ -7407,6 +7447,14 @@
 /obj/structure/maintenance_loot_structure/file_cabinet/random,
 /obj/machinery/light/cold/dim/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
+/area/gakster_location/war)
+"NZ" = (
+/mob/living/simple_animal/hostile/true_changeling{
+	name = "???";
+	health = 750
+	},
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/iron/smooth,
 /area/gakster_location/war)
 "Ob" = (
 /obj/structure/mineral_door/paperframe,
@@ -7903,7 +7951,7 @@
 /obj/item/toy/figure/ninja{
 	pixel_y = 16
 	},
-/turf/open/floor/bamboo/tatami/black,
+/turf/open/indestructible/plating,
 /area/gakster_location/ninja_hideout)
 "QH" = (
 /obj/machinery/vending/coffee,
@@ -7961,6 +8009,10 @@
 /obj/structure/fluff/big_chain,
 /turf/open/openspace,
 /area/gakster_location/outside)
+"QU" = (
+/obj/structure/table,
+/turf/open/indestructible/plating,
+/area/gakster_location/ninja_hideout)
 "QV" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/indestructible/dark/smooth_large,
@@ -8390,6 +8442,13 @@
 /obj/effect/landmark/observer_start,
 /turf/open/indestructible/plating,
 /area/gakster_location/hideout_real)
+"Th" = (
+/obj/machinery/light/dim/directional/west,
+/obj/machinery/computer{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/gakster_location/war)
 "Tk" = (
 /obj/structure/sink/directional/north,
 /turf/open/indestructible/hoteltile,
@@ -8948,6 +9007,11 @@
 /obj/machinery/camera/directional/west,
 /turf/open/openspace,
 /area/gakster_location/outside)
+"We" = (
+/obj/machinery/computer/terminal,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/gakster_location/war)
 "Wg" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -9328,7 +9392,7 @@
 /area/gakster_location/war)
 "Yl" = (
 /obj/machinery/cryopod/prison/directional/north,
-/turf/open/floor/bamboo/tatami/black,
+/turf/open/indestructible/plating,
 /area/gakster_location/ninja_hideout)
 "Ym" = (
 /obj/structure/rack/shelf,
@@ -9620,7 +9684,7 @@
 /turf/open/floor/wood,
 /area/gakster_location/hideout_real)
 "ZQ" = (
-/turf/open/floor/bamboo/tatami/black,
+/turf/open/indestructible/plating,
 /area/gakster_location/ninja_hideout)
 "ZS" = (
 /obj/machinery/light/dim/directional/west,
@@ -37089,22 +37153,22 @@ sI
 (70,1,3) = {"
 sI
 no
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
-xw
+gR
+Gr
+gR
+gR
+Gr
+gR
+gR
+Gr
+Th
+gR
+Gr
+gR
+gR
+Gr
+gR
+gR
 no
 no
 no
@@ -37191,22 +37255,22 @@ sI
 (71,1,3) = {"
 sI
 no
-xw
-xw
-xw
-xw
-xw
-no
-no
-no
-no
-no
-no
-no
-xw
-xw
-xw
-xw
+DU
+Bo
+bj
+Bo
+Fu
+zW
+zW
+Bo
+Bo
+Bo
+Rr
+Bo
+Bo
+Bo
+Bo
+Gr
 no
 xw
 xw
@@ -37293,22 +37357,22 @@ sI
 (72,1,3) = {"
 sI
 no
-xw
-xw
-xw
-xw
-xw
-no
 iU
+Bo
+Bo
+zW
+re
+Bo
+Bo
 JY
 qW
-Rr
-Gr
-no
-UE
-xw
-xw
-xw
+Bo
+Bo
+re
+Bo
+zW
+TX
+PD
 no
 xw
 xw
@@ -37395,22 +37459,22 @@ sI
 (73,1,3) = {"
 sI
 no
-xw
-xw
-xw
-xw
-xw
+We
+NZ
+pI
 no
-bj
-Fu
 Bo
-Ok
-Gr
+Bo
+Bo
+Fu
 no
-UE
-xw
-xw
-xw
+Ok
+Bo
+Bo
+TX
+no
+zW
+GR
 no
 xw
 xw
@@ -37497,22 +37561,22 @@ sI
 (74,1,3) = {"
 sI
 no
-xw
-xw
-xw
-xw
-xw
-no
+zZ
+Bo
+Bo
+Ok
+ng
+ng
 tl
-Rr
-eI
+Bo
+Bo
 nQ
+Bo
+Bo
 re
-no
-xw
-xw
-xw
-xw
+Fu
+zW
+PD
 no
 xw
 xw
@@ -37599,22 +37663,22 @@ sI
 (75,1,3) = {"
 sI
 no
-xw
-xw
-xw
-xw
-xw
-no
 Gr
+Bo
+zW
+Bo
+mn
+no
+LD
 Ok
 Ck
 Yf
-Gr
+LD
 no
-xw
-xw
-xw
-xw
+Bo
+zW
+Bo
+Gr
 no
 xw
 xw
@@ -37701,9 +37765,9 @@ sI
 (76,1,3) = {"
 sI
 no
-xw
-xw
-xw
+gR
+Bo
+Bo
 no
 no
 no
@@ -37803,9 +37867,9 @@ sI
 (77,1,3) = {"
 sI
 no
-xw
-xw
-xw
+gR
+jf
+Bo
 no
 Bo
 OU
@@ -37905,9 +37969,9 @@ sI
 (78,1,3) = {"
 sI
 no
-xw
-xw
-xw
+Gr
+Bo
+Bo
 no
 Bo
 JB
@@ -38007,9 +38071,9 @@ sI
 (79,1,3) = {"
 sI
 no
-xw
-xw
-xw
+gR
+Fu
+Bo
 no
 Bo
 Um
@@ -38109,9 +38173,9 @@ sI
 (80,1,3) = {"
 sI
 no
-xw
-xw
-xw
+eu
+kx
+Bo
 no
 no
 gN
@@ -38211,9 +38275,9 @@ sI
 (81,1,3) = {"
 sI
 no
-xw
-xw
-xw
+Gr
+cx
+Bo
 no
 fG
 HE
@@ -38313,9 +38377,9 @@ sI
 (82,1,3) = {"
 sI
 no
-xw
-xw
-xw
+zZ
+Bo
+Gh
 no
 Bo
 vi
@@ -38415,9 +38479,9 @@ sI
 (83,1,3) = {"
 sI
 no
-xw
-xw
-xw
+kl
+Bo
+Bo
 no
 no
 Bo
@@ -38517,9 +38581,9 @@ sI
 (84,1,3) = {"
 sI
 no
-xw
-xw
-xw
+Gr
+Bo
+Bo
 no
 Bo
 CP
@@ -38619,9 +38683,9 @@ sI
 (85,1,3) = {"
 sI
 no
-xw
-xw
-xw
+gR
+Bo
+Bo
 no
 Tx
 Lz
@@ -38721,9 +38785,9 @@ sI
 (86,1,3) = {"
 sI
 no
-xw
-xw
-xw
+eu
+Bo
+Bo
 no
 ME
 Ks
@@ -38823,9 +38887,9 @@ sI
 (87,1,3) = {"
 sI
 no
-UE
-xw
-xw
+Gr
+gR
+OJ
 no
 hY
 Lz
@@ -57599,7 +57663,7 @@ mv
 WI
 WI
 WI
-WI
+eI
 WI
 WI
 WI
@@ -57802,7 +57866,7 @@ mv
 mv
 WI
 My
-ZQ
+QU
 ZQ
 ZQ
 WI
@@ -57903,8 +57967,8 @@ mv
 mv
 mv
 WI
-WI
-ZQ
+eI
+xS
 ZQ
 ZQ
 WI


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/302fedc0-f9bb-4621-a364-afc8d6bbcdb4)
the room with the changeling in it was easy to cheese due to line of sight and the fact that most mobs don't smash barricades for whatever reason. this pr takes the path of least resistance by remodeling the room to obscure line of sight, adding additional weaker changelings, and increases the loot a little bit in the form of a couple of extra spawners. the actual good loot (a set of filtre level armor) remains unchanged

i also made the tsukomogami hideout a little shittier to reflect the fact that they're cyberpunk space criminal larpers and not literally ninjas

i didnt bother to compile and test it but i also didn't use anything tile or propwise that wasn't there so i don't think it's really necessary

also i threw a couple of catwalks on the bottommost level so people can use the rescue hook to fish what they may out of those chasms. there's only one ladder up and something big and dangerous down there, so good luck!